### PR TITLE
fix: improve MCP query log pagination and add missing filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,35 @@ All config keys map to env vars with prefix `PIHOLE_CLUSTER_ADMIN_` and `.` repl
 
 ### Dev container
 `.devcontainer/` provides a full dev environment with two Pi-hole node containers (`pihole-node1:8081`, `pihole-node2:8082`) pre-wired for testing. Open the project in VS Code and use "Reopen in Container". Two VS Code launch profiles exist for debugging backend and frontend separately.
+
+## Git workflow
+
+**Never commit directly to `main`.** All changes go through a branch and PR.
+
+Branch naming:
+- `feat/<short-description>` — new features
+- `fix/<short-description>` — bug fixes
+
+Typical flow:
+```bash
+git checkout -b feat/my-feature   # branch from main
+# ... make changes, commit ...
+git push -u origin feat/my-feature
+gh pr create --title "..." --body "..."
+# merge PR via GitHub
+```
+
+## Releasing
+
+Releases are tag-driven. Pushing a `v*.*.*` tag triggers CI (`.github/workflows/docker.yaml`) to build and push the Docker image to `ghcr.io/auto-dns/pihole-cluster-admin`.
+
+Tags on `main` only. Stable releases use `vMAJOR.MINOR.PATCH`; pre-releases use `vMAJOR.MINOR.PATCH-suffix`.
+
+```bash
+# After merging to main:
+git checkout main && git pull
+git tag -a v0.X.Y -m "<summary of changes>"
+git push origin v0.X.Y
+```
+
+The workflow tags `ghcr.io/auto-dns/pihole-cluster-admin:latest` and rolling `MAJOR.MINOR` / `MAJOR` aliases for stable releases only (no suffix).

--- a/backend/internal/http/mcp/tools.go
+++ b/backend/internal/http/mcp/tools.go
@@ -204,12 +204,15 @@ func registerTools(s *server.MCPServer, d Deps) {
 	), makeSetNodeBlocking(d))
 
 	s.AddTool(mcp.NewTool("get_query_logs",
-		mcp.WithDescription("Fetch recent DNS query logs across all Pi-hole nodes, interleaved newest-first. Default window: last 5 minutes."),
+		mcp.WithDescription("Fetch DNS query logs across all Pi-hole nodes, interleaved newest-first. Default window: last 5 minutes. Set disk=true to query the long-term FTL database (required for history older than a few hours). Pass the cursor from a previous response to page backward through results."),
 		mcp.WithString("from", mcp.Description("ISO 8601 start time (e.g. 2025-01-15T10:00:00Z). Defaults to 5 minutes ago.")),
 		mcp.WithString("until", mcp.Description("ISO 8601 end time. Defaults to now.")),
 		mcp.WithString("domain", mcp.Description("Filter: domain substring to match.")),
 		mcp.WithString("client_ip", mcp.Description("Filter: client IP address.")),
+		mcp.WithString("status", mcp.Description("Filter by query status: GRAVITY (blocklist), SPECIAL_DOMAIN, FORWARDED, CACHED, BLOCKED, etc.")),
+		mcp.WithBoolean("disk", mcp.Description("Query the long-term FTL database instead of in-memory log. Required for history older than a few hours.")),
 		mcp.WithNumber("length", mcp.Description("Max entries per node (default 50, max 500).")),
+		mcp.WithString("cursor", mcp.Description("Pagination cursor from a previous response. Omit for first page.")),
 	), makeGetQueryLogs(d))
 
 	s.AddTool(mcp.NewTool("list_domain_rules",
@@ -291,6 +294,9 @@ func makeGetQueryLogs(d Deps) server.ToolHandlerFunc {
 			},
 		}
 
+		if v := req.GetString("cursor", ""); v != "" {
+			q.Cursor = &v
+		}
 		if v := req.GetString("from", ""); v != "" {
 			t, err := time.Parse(time.RFC3339, v)
 			if err != nil {
@@ -310,6 +316,13 @@ func makeGetQueryLogs(d Deps) server.ToolHandlerFunc {
 		}
 		if v := req.GetString("client_ip", ""); v != "" {
 			q.Filters.ClientIP = &v
+		}
+		if v := req.GetString("status", ""); v != "" {
+			q.Filters.Status = &v
+		}
+		if req.GetBool("disk", false) {
+			disk := true
+			q.Filters.Disk = &disk
 		}
 		n := req.GetInt("length", 50)
 		if n > 500 {

--- a/backend/internal/pihole/cluster.go
+++ b/backend/internal/pihole/cluster.go
@@ -104,7 +104,7 @@ func (c *Cluster) HasClient(ctx context.Context, id int64) bool {
 
 func (c *Cluster) GetBlockingState(ctx context.Context) map[int64]*domain.NodeResult[*domain.BlockingState] {
 	logs.Event(ctx, c.logger).Msg("getting block status from all pihole nodes")
-	out, _ := fanout(c, ctx, 0, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.BlockingState, error) {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.BlockingState, error) {
 		return client.GetBlockingState(nodeCtx)
 	})
 	return out
@@ -112,7 +112,7 @@ func (c *Cluster) GetBlockingState(ctx context.Context) map[int64]*domain.NodeRe
 
 func (c *Cluster) SetBlockingState(ctx context.Context, blocking bool, timer *int) map[int64]*domain.NodeResult[*domain.BlockingState] {
 	c.logger.Debug().Msg("setting block status on all pihole nodes")
-	out, _ := fanout(c, ctx, 0, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.BlockingState, error) {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.BlockingState, error) {
 		return client.SetBlockingState(nodeCtx, blocking, timer)
 	})
 	return out
@@ -180,7 +180,7 @@ func (c *Cluster) FetchQueryLogs(ctx context.Context, req domain.QueryLogQuery) 
 	}
 
 	// Create result map
-	responses, err := fanout(c, ctx, 0, func(nodeCtx context.Context, id int64, client clientPort) (*domain.QueryLogPage, error) {
+	responses, err := fanout(c, ctx, 0, 12*time.Second, func(nodeCtx context.Context, id int64, client clientPort) (*domain.QueryLogPage, error) {
 		// Build request
 		wireReq := queriesWireRequest{
 			Filters: domainFiltersToWire(req.Filters),
@@ -228,18 +228,26 @@ func (c *Cluster) FetchQueryLogs(ctx context.Context, req domain.QueryLogQuery) 
 		}, nil
 	}
 
-	// Create a new cursor snapshot
+	// All successful nodes returned cursor=0 → no more data (catches zero-result first pages too)
+	allDone := true
+	for _, cursor := range nextPiholeCursors {
+		if cursor != 0 {
+			allDone = false
+			break
+		}
+	}
+
 	newCursor := c.cursorManager.CreateCursor(req.Filters, nextPiholeCursors)
 	return &domain.ClusterQueryLogResponse{
 		Cursor:       newCursor,
 		Results:      responses,
-		EndOfResults: false,
+		EndOfResults: allDone,
 	}, nil
 }
 
 func (c *Cluster) ListDomainRules(ctx context.Context, q domain.ListDomainRulesQuery) map[int64]*domain.NodeResult[*domain.DomainRuleSet] {
 	c.logger.Debug().Msg("getting domain rules from all pihole nodes")
-	out, _ := fanout(c, ctx, 0, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.DomainRuleSet, error) {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.DomainRuleSet, error) {
 		return client.ListDomainRules(nodeCtx, q)
 	})
 	return out
@@ -247,7 +255,7 @@ func (c *Cluster) ListDomainRules(ctx context.Context, q domain.ListDomainRulesQ
 
 func (c *Cluster) AddDomainRule(ctx context.Context, cmd domain.AddDomainRulesCommand) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult] {
 	c.logger.Debug().Msg("adding domain rule to all pihole nodes")
-	out, _ := fanout(c, ctx, 0, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.AddDomainRulesResult, error) {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.AddDomainRulesResult, error) {
 		return client.AddDomainRule(nodeCtx, cmd)
 	})
 	return out
@@ -255,7 +263,7 @@ func (c *Cluster) AddDomainRule(ctx context.Context, cmd domain.AddDomainRulesCo
 
 func (c *Cluster) RemoveDomainRule(ctx context.Context, cmd domain.RemoveDomainRuleCommand) map[int64]*domain.NodeResult[struct{}] {
 	c.logger.Debug().Msg("removing domain rule from all pihole nodes")
-	out, _ := fanout(c, ctx, 0, func(nodeCtx context.Context, _ int64, client clientPort) (struct{}, error) {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (struct{}, error) {
 		return struct{}{}, client.RemoveDomainRule(nodeCtx, cmd)
 	})
 	return out
@@ -263,7 +271,7 @@ func (c *Cluster) RemoveDomainRule(ctx context.Context, cmd domain.RemoveDomainR
 
 func (c *Cluster) AuthStatus(ctx context.Context) map[int64]*domain.NodeResult[*domain.AuthStatus] {
 	c.logger.Trace().Msg("getting auth status for cluster")
-	out, _ := fanout(c, ctx, 0, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.AuthStatus, error) {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.AuthStatus, error) {
 		return client.AuthStatus(nodeCtx)
 	})
 	return out
@@ -271,7 +279,7 @@ func (c *Cluster) AuthStatus(ctx context.Context) map[int64]*domain.NodeResult[*
 
 func (c *Cluster) Logout(ctx context.Context) map[int64]*domain.NodeResult[struct{}] {
 	c.logger.Debug().Msg("logging out all pihole nodes")
-	out, _ := fanout(c, ctx, 0, func(nodeCtx context.Context, _ int64, client clientPort) (struct{}, error) {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (struct{}, error) {
 		return struct{}{}, client.Logout(nodeCtx)
 	})
 	return out
@@ -281,6 +289,7 @@ func fanout[T any](
 	c *Cluster,
 	ctx context.Context,
 	limit int,
+	maxNodeTimeout time.Duration,
 	op func(ctx context.Context, id int64, client clientPort) (T, error),
 ) (map[int64]*domain.NodeResult[T], error) {
 	logs.Event(ctx, c.logger).Msg("fanout: starting operation on all pihole nodes")
@@ -319,11 +328,10 @@ func fanout[T any](
 				defer func() { <-sem }()
 			}
 
-			nodeTimeout := 3 * time.Second
+			nodeTimeout := maxNodeTimeout
 			if dl, ok := gctx.Deadline(); ok {
-				nodeTimeout = time.Until(dl) / 2
-				if nodeTimeout > 3*time.Second {
-					nodeTimeout = 3 * time.Second
+				if remaining := time.Until(dl) / 2; remaining < nodeTimeout {
+					nodeTimeout = remaining
 				}
 			}
 			nodeCtx, cancel := context.WithTimeout(gctx, nodeTimeout)


### PR DESCRIPTION
## Summary

- **Add `cursor`, `status`, and `disk` params to `get_query_logs` MCP tool** — makes real pagination possible, enables server-side status filtering (e.g. `status=GRAVITY` for blocked-only), and exposes `disk=true` to query the FTL long-term database (previously the MCP tool only had access to in-memory queries, capping history to ~4.5h)
- **Fix `EndOfResults` always `false` on first-page zero-result responses** — when all Pi-hole nodes return cursor=0 (no data), `endOfResults` is now correctly set to `true` even on the initial page
- **Increase query log fanout timeout from 3s to 12s** — FTL disk queries on large time windows can exceed 3s; other operations keep their 3s timeout via a new `maxNodeTimeout` parameter on `fanout()`
- **Document branching and release process in CLAUDE.md**

## Test plan

- [ ] `get_query_logs` with `status=GRAVITY&disk=true` returns blocked queries from the last 24h in 1-2 pages instead of requiring 120+ calls
- [ ] `endOfResults` is `true` when querying a time window with no results
- [ ] Paginating with `cursor` from a previous response returns the next page correctly
- [ ] All other MCP tools (blocking, domain rules, health) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)