### PR TITLE
Fix blocking status flicker on page load

### DIFF
--- a/frontend/src/components/ClusterHeader/ClusterHeader.tsx
+++ b/frontend/src/components/ClusterHeader/ClusterHeader.tsx
@@ -100,6 +100,7 @@ export function NodeBlockingStatusCard({
 	fresh,
 	updatedAt,
 }: NodeBlockingStatusCardProps) {
+	if (blocking === undefined) return null;
 	const display = getBlockingDisplayState(blocking?.summary);
 	const { icon: Icon, colorVar, variant } = display;
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -14,10 +14,14 @@ export function Home() {
 				<h2 id="cluster-status-heading" className={styles.sectionTitle}>Cluster Status</h2>
 				<div className={styles.summaryCards}>
 					<div className={styles.card}>
-						<div className={styles.blockingRow}>
-							<StatusIcon size={22} style={{ color: colorVar }} aria-hidden />
-							<span className={styles.blockingLabel}>{blockingLabel}</span>
-						</div>
+						{blocking !== undefined ? (
+							<div className={styles.blockingRow}>
+								<StatusIcon size={22} style={{ color: colorVar }} aria-hidden />
+								<span className={styles.blockingLabel}>{blockingLabel}</span>
+							</div>
+						) : (
+							<div className={styles.statValue}>—</div>
+						)}
 						<div className={styles.cardSub}>Blocking</div>
 					</div>
 					<div className={styles.card}>


### PR DESCRIPTION
## Summary

- `NodeBlockingStatusCard` now returns `null` while `blocking` is `undefined`, preventing the degraded/red triangle from flashing before the first SSE event arrives
- `Home.tsx` blocking card shows `—` while loading, matching the existing `healthSummary ? ... : '—'` pattern on the nodes card

## Root cause

`getBlockingDisplayState(undefined)` defaults `mode` to `'degraded'`, returning the red `AlertTriangle`. Since `blocking` initializes as `undefined` and the first SSE/API response takes ~200ms, the wrong state was briefly visible on every page load.

## Test plan

- [ ] Load the app and confirm no red triangle flash in the sidebar header before blocking state arrives
- [ ] Load the Home page and confirm the Blocking card shows `—` briefly, then the correct icon
- [ ] Confirm correct blocking state renders after SSE settles

🤖 Generated with [Claude Code](https://claude.com/claude-code)