### PR TITLE
chore: upgrade Go to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY frontend/ .
 RUN npm install && npm run build
 
 # ===== Stage 2: Build Go Backend =====
-FROM golang:1.25-bookworm AS backend-builder
+FROM golang:1.26.3-bookworm AS backend-builder
 WORKDIR /backend
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download
@@ -16,7 +16,7 @@ COPY --from=frontend-builder /frontend/dist ./internal/frontend/dist
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o pihole-cluster-admin ./cmd/pihole-cluster-admin
 
 # ===== Stage 3: Dev Container =====
-FROM mcr.microsoft.com/devcontainers/go:1.24 AS dev
+FROM mcr.microsoft.com/devcontainers/go:1.26 AS dev
 # Remove Yarn repo (GPG key often expired) before apt-get update
 RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null || true
 ENV DEBIAN_FRONTEND=noninteractive

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/auto-dns/pihole-cluster-admin
 
-go 1.25.5
+go 1.26.3
 
 require (
 	github.com/rs/zerolog v1.34.0


### PR DESCRIPTION
## Summary
- Update `go` directive in `go.mod` from 1.25.5 to 1.26.3
- Update backend-builder Dockerfile stage from `golang:1.25-bookworm` to `golang:1.26.3-bookworm`
- Fix dev container mismatch: upgrade from `devcontainers/go:1.24` to `devcontainers/go:1.26`

## Test plan
- [ ] CI builds Docker image successfully on the new base

🤖 Generated with [Claude Code](https://claude.com/claude-code)