### PR TITLE
feat: add CSRF protection via double-submit cookie pattern

### DIFF
--- a/backend/internal/http/api/v1/auth_handlers.go
+++ b/backend/internal/http/api/v1/auth_handlers.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"net/http"
 	"time"
 
@@ -9,6 +11,14 @@ import (
 	authsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/auth"
 	"github.com/go-chi/chi"
 )
+
+func generateCSRFToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
 
 func registerAuthPublic(r chi.Router, d Deps) {
 	r.Post("/login", authLogin(d))
@@ -40,7 +50,15 @@ func authLogin(d Deps) http.HandlerFunc {
 
 		res := fromDomainUser(user)
 
+		csrfToken, err := generateCSRFToken()
+		if err != nil {
+			d.Logger.Error().Err(err).Msg("generating CSRF token")
+			transport.WriteErr(w, err)
+			return
+		}
+
 		http.SetCookie(w, d.HttpCookieFactory.Make(sessionId))
+		http.SetCookie(w, d.HttpCookieFactory.MakeCSRF(csrfToken))
 		transport.WriteJSON(w, http.StatusOK, res)
 	}
 }
@@ -58,6 +76,12 @@ func authLogout(d Deps) http.HandlerFunc {
 		expired := d.HttpCookieFactory.Make("")
 		expired.Expires = time.Now().Add(-1 * time.Hour)
 		http.SetCookie(w, expired)
+
+		expiredCSRF := d.HttpCookieFactory.MakeCSRF("")
+		expiredCSRF.Expires = time.Now().Add(-1 * time.Hour)
+		expiredCSRF.MaxAge = -1
+		http.SetCookie(w, expiredCSRF)
+
 		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/backend/internal/http/api/v1/interface.go
+++ b/backend/internal/http/api/v1/interface.go
@@ -60,5 +60,6 @@ type userService interface {
 
 type httpCookieFactory interface {
 	Make(value string) *http.Cookie
+	MakeCSRF(token string) *http.Cookie
 	Name() string
 }

--- a/backend/internal/http/api/v1/router.go
+++ b/backend/internal/http/api/v1/router.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"net/http"
 
+	"github.com/auto-dns/pihole-cluster-admin/internal/http/middleware"
 	"github.com/go-chi/chi"
 	"github.com/rs/zerolog"
 )
@@ -37,6 +38,7 @@ func RegisterAPIV1(r chi.Router, d Deps) {
 	// Private
 	r.Group(func(r chi.Router) {
 		r.Use(d.AuthMW)
+		r.Use(middleware.CSRF)
 		registerAuthPrivate(r, d)
 		registerClusterBlocking(r, d)
 		registerHealth(r, d)

--- a/backend/internal/http/api/v1/setup_handlers.go
+++ b/backend/internal/http/api/v1/setup_handlers.go
@@ -71,7 +71,15 @@ func setupCreateUser(d Deps) http.HandlerFunc {
 
 		res := fromDomainUser(user)
 
+		csrfToken, err := generateCSRFToken()
+		if err != nil {
+			d.Logger.Error().Err(err).Msg("generating CSRF token")
+			transport.WriteErr(w, err)
+			return
+		}
+
 		http.SetCookie(w, d.HttpCookieFactory.Make(sessionId))
+		http.SetCookie(w, d.HttpCookieFactory.MakeCSRF(csrfToken))
 		transport.WriteJSON(w, http.StatusCreated, res)
 	}
 }

--- a/backend/internal/http/cookies/factory.go
+++ b/backend/internal/http/cookies/factory.go
@@ -37,6 +37,23 @@ func (f *SessionCookieFactory) Make(value string) *http.Cookie {
 	}
 }
 
+func (f *SessionCookieFactory) MakeCSRF(token string) *http.Cookie {
+	ttl := time.Duration(f.cfg.TTLHours) * time.Hour
+	secure := f.cfg.Secure && !f.cfg.AllowInsecureCookie
+	expires := time.Now().UTC().Add(ttl)
+
+	return &http.Cookie{
+		Name:     "csrf_token",
+		Value:    token,
+		Path:     f.cfg.CookiePath,
+		HttpOnly: false, // JS must read this to send it as a header
+		Secure:   secure,
+		SameSite: parseSameSite(f.cfg.SameSite),
+		Expires:  expires,
+		MaxAge:   int(ttl.Seconds()),
+	}
+}
+
 func parseSameSite(val string) http.SameSite {
 	switch strings.ToLower(val) {
 	case "lax":

--- a/backend/internal/http/middleware/csrf.go
+++ b/backend/internal/http/middleware/csrf.go
@@ -1,0 +1,36 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+const (
+	CSRFHeaderName = "X-CSRF-Token"
+	CSRFCookieName = "csrf_token"
+)
+
+// CSRF implements the double-submit cookie pattern. On mutating requests it
+// verifies that the X-CSRF-Token header matches the csrf_token cookie value.
+// Safe methods (GET, HEAD, OPTIONS) are unconditionally allowed.
+func CSRF(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		cookie, err := r.Cookie(CSRFCookieName)
+		if err != nil || cookie.Value == "" {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+
+		if r.Header.Get(CSRFHeaderName) != cookie.Value {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/frontend/src/components/Layout/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout/AppLayout.tsx
@@ -32,7 +32,9 @@ export function AppLayout() {
 					{layoutOptions.showSidebar && <Sidebar />}
 
 					<div className={styles.rightPane}>
-						{layoutOptions.showToolbar && <Toolbar pageTitle={layoutOptions.pageTitle} />}
+						{layoutOptions.showToolbar && (
+							<Toolbar pageTitle={layoutOptions.pageTitle} />
+						)}
 						<main className={styles.content} role='main' id='main'>
 							<Outlet />
 						</main>

--- a/frontend/src/components/PiholeManagementList/PiholeCardList/PiholeCardList.tsx
+++ b/frontend/src/components/PiholeManagementList/PiholeCardList/PiholeCardList.tsx
@@ -11,7 +11,6 @@ type Props = {
 };
 
 export function PiholeCardList({ nodes, nodeHealthById, isFresh, onCardClick }: Props) {
-
 	return (
 		<ul className={styles.cardList} role='list' aria-label='Configured Pi-hole nodes'>
 			{nodes.map((node) => {

--- a/frontend/src/components/PiholeManagementList/PiholeManagementList/PiholeManagementList.tsx
+++ b/frontend/src/components/PiholeManagementList/PiholeManagementList/PiholeManagementList.tsx
@@ -38,7 +38,12 @@ export function PiholeManagementList() {
 
 					{/* Desktop table */}
 					<div className={styles.tableWrap}>
-						<PiholeTable nodes={piholeNodes} nodeHealthById={nodeHealthById} isFresh={isFresh} onRowClick={(node) => setEditing(node)} />
+						<PiholeTable
+							nodes={piholeNodes}
+							nodeHealthById={nodeHealthById}
+							isFresh={isFresh}
+							onRowClick={(node) => setEditing(node)}
+						/>
 					</div>
 
 					{/* Mobile cards */}

--- a/frontend/src/components/PiholeManagementList/PiholeTable/PiholeTable.tsx
+++ b/frontend/src/components/PiholeManagementList/PiholeTable/PiholeTable.tsx
@@ -12,7 +12,6 @@ type Props = {
 };
 
 export function PiholeTable({ nodes, nodeHealthById, isFresh, onRowClick }: Props) {
-
 	return (
 		<div className={styles.tableCard}>
 			<table className={styles.table}>

--- a/frontend/src/hooks/useClusterBlocking.ts
+++ b/frontend/src/hooks/useClusterBlocking.ts
@@ -57,7 +57,7 @@ export function useClusterBlocking() {
 			const overrideId = opts?.overrideNodeTimer?.nodeId;
 			const nodeFromResponse =
 				overrideId != null && next.nodes
-					? next.nodes[overrideId] ?? next.nodes[String(overrideId)]
+					? (next.nodes[overrideId] ?? next.nodes[String(overrideId)])
 					: undefined;
 			if (opts?.overrideNodeTimer != null && nodeFromResponse) {
 				const id = opts.overrideNodeTimer.nodeId;
@@ -82,10 +82,7 @@ export function useClusterBlocking() {
 				const nodes: Record<number, ClusterBlockingNode> = {};
 				for (const [k, node] of Object.entries(next.nodes)) {
 					const id = Number(k);
-					nodes[id] =
-						node.blocking === 'disabled'
-							? { ...node, timer: sec }
-							: node;
+					nodes[id] = node.blocking === 'disabled' ? { ...node, timer: sec } : node;
 				}
 				toApply = { ...next, nodes };
 			}
@@ -119,31 +116,40 @@ export function useClusterBlocking() {
 				...state.nodes,
 				[nodeId]: { ...node, blocking: 'enabled' as const, timer: null },
 			};
-			const enabledCount = Object.values(newNodes).filter((n) => n.blocking === 'enabled').length;
-			const disabledCount = Object.values(newNodes).filter((n) => n.blocking === 'disabled').length;
+			const enabledCount = Object.values(newNodes).filter(
+				(n) => n.blocking === 'enabled',
+			).length;
+			const disabledCount = Object.values(newNodes).filter(
+				(n) => n.blocking === 'disabled',
+			).length;
 			const total = Object.keys(newNodes).length;
 			const mode =
 				disabledCount === total ? 'disabled' : enabledCount === total ? 'enabled' : 'mixed';
 			lastApplyAt.current = Date.now();
-			setState({
-				...state,
-				summary: {
-					...state.summary,
-					mode,
-					unanimous: enabledCount === total || disabledCount === total,
-					counts: {
-						...state.summary.counts,
-						enabled: enabledCount,
-						disabled: disabledCount,
-						total,
+			setState(
+				{
+					...state,
+					summary: {
+						...state.summary,
+						mode,
+						unanimous: enabledCount === total || disabledCount === total,
+						counts: {
+							...state.summary.counts,
+							enabled: enabledCount,
+							disabled: disabledCount,
+							total,
+						},
+						timers: {
+							...state.summary.timers,
+							present:
+								disabledCount > 0 &&
+								Object.values(newNodes).some((n) => n.timer != null && n.timer > 0),
+						},
 					},
-					timers: {
-						...state.summary.timers,
-						present: disabledCount > 0 && Object.values(newNodes).some((n) => n.timer != null && n.timer > 0),
-					},
+					nodes: newNodes,
 				},
-				nodes: newNodes,
-			}, { keepReceivedAt: true });
+				{ keepReceivedAt: true },
+			);
 		},
 		[state, setState],
 	);
@@ -187,8 +193,12 @@ export function useClusterBlocking() {
 				...state.nodes,
 				[nodeId]: { ...node, blocking: 'disabled', timer: timerSeconds },
 			};
-			const enabledCount = Object.values(newNodes).filter((n) => n.blocking === 'enabled').length;
-			const disabledCount = Object.values(newNodes).filter((n) => n.blocking === 'disabled').length;
+			const enabledCount = Object.values(newNodes).filter(
+				(n) => n.blocking === 'enabled',
+			).length;
+			const disabledCount = Object.values(newNodes).filter(
+				(n) => n.blocking === 'disabled',
+			).length;
 			const total = Object.keys(newNodes).length;
 			const mode =
 				disabledCount === total ? 'disabled' : enabledCount === total ? 'enabled' : 'mixed';

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -3,18 +3,31 @@ import { HttpError } from '@/types';
 const API_ROOT = '/api';
 const API_VERSION = 'v1';
 const API_PREFIX = `${API_ROOT}/${API_VERSION}`;
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'DELETE', 'PATCH']);
 
 function join(base: string, path: string) {
 	return `${base}${path.startsWith('/') ? path : `/${path}`}`;
 }
 
+function getCsrfToken(): string {
+	const match = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/);
+	return match ? decodeURIComponent(match[1]) : '';
+}
+
 export async function apiV1Fetch<T = unknown>(path: string, options: RequestInit = {}): Promise<T> {
 	const url = join(API_PREFIX, path);
+	const method = (options.method || 'GET').toUpperCase();
+	const csrfHeaders: Record<string, string> = {};
+	if (MUTATING_METHODS.has(method)) {
+		const token = getCsrfToken();
+		if (token) csrfHeaders['X-CSRF-Token'] = token;
+	}
 
 	const resp = await fetch(url, {
 		...options,
 		headers: {
 			'Content-Type': 'application/json',
+			...csrfHeaders,
 			...(options.headers || {}),
 		},
 		credentials: 'include',

--- a/frontend/src/pages/Blocking/Blocking.tsx
+++ b/frontend/src/pages/Blocking/Blocking.tsx
@@ -53,8 +53,6 @@ export function Blocking() {
 		applyOptimisticClusterDisable,
 		requestedNodeDisplay,
 		clearRequestedNodeDisplay,
-		setRequestedTimerDisplay,
-		clearRequestedTimer,
 	} = clusterOverview;
 
 	const [clusterSubmitting, setClusterSubmitting] = useState(false);
@@ -106,9 +104,11 @@ export function Blocking() {
 		return Math.max(0, nodeTimer - elapsed);
 	}
 	const nodeRemainings = new Map<number, number | null>(
-		nodes.map((n, idx) => {
+		nodes.map((n) => {
 			const pending =
-				pendingNodeDisplay != null && pendingNodeDisplay.nodeId == n.id ? pendingNodeDisplay : null;
+				pendingNodeDisplay != null && pendingNodeDisplay.nodeId == n.id
+					? pendingNodeDisplay
+					: null;
 			const useOverride =
 				pending ?? (requestedNodeDisplay?.nodeId == n.id ? requestedNodeDisplay : null);
 			const timer = useOverride ? useOverride.seconds : n.timer;
@@ -128,7 +128,8 @@ export function Blocking() {
 								? pendingNodeDisplay
 								: null;
 						const useOverride =
-							pending ?? (requestedNodeDisplay?.nodeId == n.id ? requestedNodeDisplay : null);
+							pending ??
+							(requestedNodeDisplay?.nodeId == n.id ? requestedNodeDisplay : null);
 						const timer = useOverride ? useOverride.seconds : n.timer;
 						const at = useOverride ? useOverride.requestedAt : receivedAtMs;
 						return getNodeRemaining(timer, at) ?? 0;
@@ -167,12 +168,7 @@ export function Blocking() {
 				setOptimisticNodeEnabled(nid);
 			}
 		}
-	}, [
-		clusterRemaining,
-		anyNodeHasTimer,
-		nodeRemainings,
-		setOptimisticNodeEnabled,
-	]);
+	}, [clusterRemaining, anyNodeHasTimer, nodeRemainings, setOptimisticNodeEnabled]);
 
 	async function handleClusterEnable() {
 		setClusterError(null);
@@ -224,7 +220,9 @@ export function Blocking() {
 		try {
 			const next = await setNodeBlocking(nodeId, { blocking: false, timer: timerSeconds });
 			setPendingNodeDisplay((prev) =>
-				prev?.nodeId === nodeId ? { nodeId, seconds: timerSeconds, requestedAt: Date.now() } : prev,
+				prev?.nodeId === nodeId
+					? { nodeId, seconds: timerSeconds, requestedAt: Date.now() }
+					: prev,
 			);
 			applyBlockingState(next, {
 				overrideNodeTimer: { nodeId, seconds: timerSeconds },
@@ -250,8 +248,8 @@ export function Blocking() {
 
 	return (
 		<div className={styles.page}>
-			<section className={styles.clusterSection} aria-labelledby="cluster-status-heading">
-				<h2 id="cluster-status-heading" className={styles.sectionTitle}>
+			<section className={styles.clusterSection} aria-labelledby='cluster-status-heading'>
+				<h2 id='cluster-status-heading' className={styles.sectionTitle}>
 					Cluster
 				</h2>
 				<div className={styles.clusterCard}>
@@ -265,7 +263,7 @@ export function Blocking() {
 						<div>
 							<span className={styles.statusLabel}>{statusLabel}</span>
 							{showClusterCountdown && (
-								<span className={styles.countdown} aria-live="polite">
+								<span className={styles.countdown} aria-live='polite'>
 									{formatCountdown(clusterRemaining)} left
 								</span>
 							)}
@@ -275,7 +273,7 @@ export function Blocking() {
 					<div className={styles.actions}>
 						{showClusterEnableButton && (
 							<button
-								type="button"
+								type='button'
 								className={styles.primaryButton}
 								onClick={handleClusterEnable}
 								disabled={clusterSubmitting}
@@ -289,11 +287,15 @@ export function Blocking() {
 								Enable blocking
 							</button>
 						)}
-						<div className={styles.presets} role="group" aria-label="Disable blocking for a duration">
+						<div
+							className={styles.presets}
+							role='group'
+							aria-label='Disable blocking for a duration'
+						>
 							{CLUSTER_PRESETS.map(({ label, seconds }) => (
 								<button
 									key={label}
-									type="button"
+									type='button'
 									className={styles.presetButton}
 									onClick={() => handleClusterDisable(seconds)}
 									disabled={clusterSubmitting}
@@ -305,12 +307,12 @@ export function Blocking() {
 							))}
 						</div>
 						<div className={styles.customRow}>
-							<label htmlFor="blocking-custom-value" className={styles.customLabel}>
+							<label htmlFor='blocking-custom-value' className={styles.customLabel}>
 								Custom:
 							</label>
 							<input
-								id="blocking-custom-value"
-								type="number"
+								id='blocking-custom-value'
+								type='number'
 								min={1}
 								max={CUSTOM_UNITS.find((u) => u.value === customUnit)?.max ?? 86400}
 								value={customSeconds}
@@ -320,7 +322,7 @@ export function Blocking() {
 								}}
 								className={styles.customInput}
 								disabled={clusterSubmitting}
-								aria-label="Custom duration"
+								aria-label='Custom duration'
 							/>
 							<span className={styles.unitSelectWrap}>
 								<select
@@ -328,7 +330,7 @@ export function Blocking() {
 									value={customUnit}
 									onChange={(e) => setCustomUnit(e.target.value as CustomUnit)}
 									disabled={clusterSubmitting}
-									aria-label="Time unit"
+									aria-label='Time unit'
 								>
 									{CUSTOM_UNITS.map(({ value, label }) => (
 										<option key={value} value={value}>
@@ -336,12 +338,18 @@ export function Blocking() {
 										</option>
 									))}
 								</select>
-								<ChevronDown size={16} className={styles.unitSelectIcon} aria-hidden />
+								<ChevronDown
+									size={16}
+									className={styles.unitSelectIcon}
+									aria-hidden
+								/>
 							</span>
 							<button
-								type="button"
+								type='button'
 								className={styles.presetButton}
-								onClick={() => handleClusterDisable(customToSeconds(customSeconds, customUnit))}
+								onClick={() =>
+									handleClusterDisable(customToSeconds(customSeconds, customUnit))
+								}
 								disabled={
 									clusterSubmitting ||
 									customSeconds <= 0 ||
@@ -356,123 +364,150 @@ export function Blocking() {
 				</div>
 			</section>
 
-			<section className={styles.nodesSection} aria-labelledby="nodes-heading">
-				<h2 id="nodes-heading" className={styles.sectionTitle}>
+			<section className={styles.nodesSection} aria-labelledby='nodes-heading'>
+				<h2 id='nodes-heading' className={styles.sectionTitle}>
 					Nodes
 				</h2>
 				<div className={styles.nodeGrid}>
-					{nodes.map(({ id, node, blocking: nodeBlocking, timer: nodeTimer, error: nodeError }) => {
-						const nodeDisabled =
-							nodeBlocking === 'disabled' ||
-							requestedNodeDisplay?.nodeId == id ||
-							(pendingNodeDisplay != null && pendingNodeDisplay.nodeId == id);
-						const remaining = nodeRemainings.get(id);
-						const hasTimeLeft = remaining != null && remaining > 0;
-						const isSubmitting = submittingNodeId === id;
-						const nodeCustomValue = customSecondsByNode[id] ?? 60;
-						const nodeUnit = customUnitByNode[id] ?? 'mins';
-						const nodeCustomSeconds = customToSeconds(nodeCustomValue, nodeUnit);
-						return (
-							<div key={id} className={styles.nodeCard} data-status={nodeBlocking}>
-								<div className={styles.nodeTop}>
-									<div className={styles.nodeHeader}>
-										<span className={styles.nodeName}>{node.name}</span>
-										<span className={styles.nodeStatus}>{nodeBlocking}</span>
-										{hasTimeLeft && (
-											<span className={styles.nodeTimer}>
-												{formatCountdown(remaining!)} left
+					{nodes.map(
+						({
+							id,
+							node,
+							blocking: nodeBlocking,
+							timer: _nodeTimer,
+							error: nodeError,
+						}) => {
+							const nodeDisabled =
+								nodeBlocking === 'disabled' ||
+								requestedNodeDisplay?.nodeId == id ||
+								(pendingNodeDisplay != null && pendingNodeDisplay.nodeId == id);
+							const remaining = nodeRemainings.get(id);
+							const hasTimeLeft = remaining != null && remaining > 0;
+							const isSubmitting = submittingNodeId === id;
+							const nodeCustomValue = customSecondsByNode[id] ?? 60;
+							const nodeUnit = customUnitByNode[id] ?? 'mins';
+							const nodeCustomSeconds = customToSeconds(nodeCustomValue, nodeUnit);
+							return (
+								<div
+									key={id}
+									className={styles.nodeCard}
+									data-status={nodeBlocking}
+								>
+									<div className={styles.nodeTop}>
+										<div className={styles.nodeHeader}>
+											<span className={styles.nodeName}>{node.name}</span>
+											<span className={styles.nodeStatus}>
+												{nodeBlocking}
 											</span>
+											{hasTimeLeft && (
+												<span className={styles.nodeTimer}>
+													{formatCountdown(remaining!)} left
+												</span>
+											)}
+										</div>
+										{nodeDisabled && hasTimeLeft && (
+											<button
+												type='button'
+												className={styles.nodeReenable}
+												onClick={() => handleNodeEnable(id)}
+												disabled={isSubmitting}
+												aria-busy={isSubmitting}
+												aria-label={`Re-enable blocking on ${node.name}`}
+											>
+												{isSubmitting ? (
+													<Loader2 size={14} className={styles.spin} />
+												) : (
+													<Shield size={14} />
+												)}
+												Re-enable
+											</button>
 										)}
 									</div>
-									{nodeDisabled && hasTimeLeft && (
-										<button
-											type="button"
-											className={styles.nodeReenable}
-											onClick={() => handleNodeEnable(id)}
-											disabled={isSubmitting}
-											aria-busy={isSubmitting}
-											aria-label={`Re-enable blocking on ${node.name}`}
-										>
-											{isSubmitting ? (
-												<Loader2 size={14} className={styles.spin} />
-											) : (
-												<Shield size={14} />
-											)}
-											Re-enable
-										</button>
-									)}
-								</div>
-								{nodeError && <p className={styles.nodeError}>{nodeError}</p>}
-								<div className={styles.nodeDisableRow} role="group" aria-label={`Disable blocking on ${node.name}`}>
-									{CLUSTER_PRESETS.map(({ label, seconds }) => (
-										<button
-											key={label}
-											type="button"
-											className={styles.nodeChip}
-											onClick={() => handleNodeDisable(id, seconds)}
-											disabled={isSubmitting}
-											aria-label={`Disable ${label} on ${node.name}`}
-										>
-											{label}
-										</button>
-									))}
-									<span className={styles.nodeCustomWrap}>
-										<input
-											id={`blocking-node-${id}-custom`}
-											type="number"
-											min={1}
-											max={CUSTOM_UNITS.find((u) => u.value === nodeUnit)?.max ?? 86400}
-											value={nodeCustomValue}
-											onChange={(e) => {
-												const v = e.target.valueAsNumber;
-												setCustomSecondsByNode((prev) => ({
-													...prev,
-													[id]: Number.isFinite(v) && v >= 0 ? v : 0,
-												}));
-											}}
-											className={styles.nodeCustomInput}
-											disabled={isSubmitting}
-											aria-label={`Custom duration for ${node.name}`}
-										/>
-										<span className={styles.nodeUnitSelectWrap}>
-											<select
-												className={styles.nodeUnitSelect}
-												value={nodeUnit}
-												onChange={(e) =>
-													setCustomUnitByNode((prev) => ({
-														...prev,
-														[id]: e.target.value as CustomUnit,
-													}))
-												}
+									{nodeError && <p className={styles.nodeError}>{nodeError}</p>}
+									<div
+										className={styles.nodeDisableRow}
+										role='group'
+										aria-label={`Disable blocking on ${node.name}`}
+									>
+										{CLUSTER_PRESETS.map(({ label, seconds }) => (
+											<button
+												key={label}
+												type='button'
+												className={styles.nodeChip}
+												onClick={() => handleNodeDisable(id, seconds)}
 												disabled={isSubmitting}
-												aria-label={`Unit for ${node.name}`}
+												aria-label={`Disable ${label} on ${node.name}`}
 											>
-												{CUSTOM_UNITS.map(({ value, label }) => (
-													<option key={value} value={value}>
-														{label}
-													</option>
-												))}
-											</select>
-											<ChevronDown size={14} className={styles.unitSelectIcon} aria-hidden />
+												{label}
+											</button>
+										))}
+										<span className={styles.nodeCustomWrap}>
+											<input
+												id={`blocking-node-${id}-custom`}
+												type='number'
+												min={1}
+												max={
+													CUSTOM_UNITS.find((u) => u.value === nodeUnit)
+														?.max ?? 86400
+												}
+												value={nodeCustomValue}
+												onChange={(e) => {
+													const v = e.target.valueAsNumber;
+													setCustomSecondsByNode((prev) => ({
+														...prev,
+														[id]: Number.isFinite(v) && v >= 0 ? v : 0,
+													}));
+												}}
+												className={styles.nodeCustomInput}
+												disabled={isSubmitting}
+												aria-label={`Custom duration for ${node.name}`}
+											/>
+											<span className={styles.nodeUnitSelectWrap}>
+												<select
+													className={styles.nodeUnitSelect}
+													value={nodeUnit}
+													onChange={(e) =>
+														setCustomUnitByNode((prev) => ({
+															...prev,
+															[id]: e.target.value as CustomUnit,
+														}))
+													}
+													disabled={isSubmitting}
+													aria-label={`Unit for ${node.name}`}
+												>
+													{CUSTOM_UNITS.map(({ value, label }) => (
+														<option key={value} value={value}>
+															{label}
+														</option>
+													))}
+												</select>
+												<ChevronDown
+													size={14}
+													className={styles.unitSelectIcon}
+													aria-hidden
+												/>
+											</span>
+											<button
+												type='button'
+												className={styles.nodeChip}
+												onClick={() =>
+													handleNodeDisable(id, nodeCustomSeconds)
+												}
+												disabled={
+													isSubmitting ||
+													nodeCustomValue <= 0 ||
+													nodeCustomSeconds > 86400
+												}
+												aria-label={`Disable ${formatCustomLabel(nodeCustomValue, nodeUnit)} on ${node.name}`}
+											>
+												{formatCustomLabel(nodeCustomValue, nodeUnit)}
+											</button>
 										</span>
-										<button
-											type="button"
-											className={styles.nodeChip}
-											onClick={() => handleNodeDisable(id, nodeCustomSeconds)}
-											disabled={
-												isSubmitting ||
-												nodeCustomValue <= 0 ||
-												nodeCustomSeconds > 86400
-											}
-											aria-label={`Disable ${formatCustomLabel(nodeCustomValue, nodeUnit)} on ${node.name}`}
-										>
-											{formatCustomLabel(nodeCustomValue, nodeUnit)}
-										</button>
-									</span>
+									</div>
 								</div>
-							</div>
-						);
-					})}
+							);
+						},
+					)}
 				</div>
 			</section>
 		</div>

--- a/frontend/src/pages/Domains.tsx
+++ b/frontend/src/pages/Domains.tsx
@@ -2,10 +2,18 @@ import { useState, useEffect, useCallback } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { Plus, Trash2, RefreshCw, X } from 'lucide-react';
 import { listDomainRules, addDomainRule, removeDomainRule } from '@/lib/api/domainrules';
-import type { ConsolidatedRule, RuleType, RuleKind, ListDomainRulesResponse } from '@/types/domainrule';
+import type {
+	ConsolidatedRule,
+	RuleType,
+	RuleKind,
+	ListDomainRulesResponse,
+} from '@/types/domainrule';
 import styles from './Domains.module.scss';
 
-function consolidate(resp: ListDomainRulesResponse): { rules: ConsolidatedRule[]; nodeNames: Map<number, string> } {
+function consolidate(resp: ListDomainRulesResponse): {
+	rules: ConsolidatedRule[];
+	nodeNames: Map<number, string>;
+} {
 	const totalNodes = Object.keys(resp.nodes).length;
 	const ruleMap = new Map<string, ConsolidatedRule>();
 	const nodeNames = new Map<number, string>();
@@ -78,11 +86,16 @@ export function Domains() {
 		}
 	}, []);
 
-	useEffect(() => { fetchRules(); }, [fetchRules]);
+	useEffect(() => {
+		fetchRules();
+	}, [fetchRules]);
 
 	async function handleAdd() {
 		setAddError(null);
-		const rawDomains = addForm.domains.split('\n').map(d => d.trim()).filter(Boolean);
+		const rawDomains = addForm.domains
+			.split('\n')
+			.map((d) => d.trim())
+			.filter(Boolean);
 		if (rawDomains.length === 0) {
 			setAddError('Enter at least one domain');
 			return;
@@ -119,16 +132,16 @@ export function Domains() {
 		}
 	}
 
-	const filtered = typeFilter === 'all' ? rules : rules.filter(r => r.type === typeFilter);
+	const filtered = typeFilter === 'all' ? rules : rules.filter((r) => r.type === typeFilter);
 
 	return (
 		<div className={styles.page}>
 			<div className={styles.toolbar}>
-				<div className={styles.typeFilter} role="group" aria-label="Filter by type">
-					{(['all', 'allow', 'deny'] as const).map(t => (
+				<div className={styles.typeFilter} role='group' aria-label='Filter by type'>
+					{(['all', 'allow', 'deny'] as const).map((t) => (
 						<button
 							key={t}
-							type="button"
+							type='button'
 							className={styles.filterBtn}
 							data-active={typeFilter === t || undefined}
 							data-type={t !== 'all' ? t : undefined}
@@ -141,18 +154,27 @@ export function Domains() {
 
 				<div className={styles.toolbarRight}>
 					<button
-						type="button"
+						type='button'
 						className={styles.refreshBtn}
 						onClick={fetchRules}
 						disabled={loading}
-						aria-label="Refresh"
+						aria-label='Refresh'
 					>
 						<RefreshCw size={16} className={loading ? styles.spin : undefined} />
 					</button>
 
-					<Dialog.Root open={addOpen} onOpenChange={(next) => { setAddOpen(next); if (!next) { setAddForm(DEFAULT_ADD_FORM); setAddError(null); } }}>
+					<Dialog.Root
+						open={addOpen}
+						onOpenChange={(next) => {
+							setAddOpen(next);
+							if (!next) {
+								setAddForm(DEFAULT_ADD_FORM);
+								setAddError(null);
+							}
+						}}
+					>
 						<Dialog.Trigger asChild>
-							<button type="button" className={styles.addBtn}>
+							<button type='button' className={styles.addBtn}>
 								<Plus size={16} />
 								Add rule
 							</button>
@@ -160,66 +182,86 @@ export function Domains() {
 						<Dialog.Portal>
 							<Dialog.Overlay className={styles.overlay} />
 							<Dialog.Content className={styles.dialog}>
-								<Dialog.Title className={styles.dialogTitle}>Add domain rule</Dialog.Title>
+								<Dialog.Title className={styles.dialogTitle}>
+									Add domain rule
+								</Dialog.Title>
 
 								<div className={styles.field}>
-									<label htmlFor="add-domains" className={styles.fieldLabel}>
+									<label htmlFor='add-domains' className={styles.fieldLabel}>
 										Domains
 										<span className={styles.fieldHint}>(one per line)</span>
 									</label>
 									<textarea
-										id="add-domains"
+										id='add-domains'
 										className={styles.textarea}
 										rows={4}
-										placeholder="example.com"
+										placeholder='example.com'
 										value={addForm.domains}
-										onChange={e => setAddForm(f => ({ ...f, domains: e.target.value }))}
+										onChange={(e) =>
+											setAddForm((f) => ({ ...f, domains: e.target.value }))
+										}
 										disabled={addSubmitting}
 									/>
 								</div>
 
 								<div className={styles.fieldRow}>
 									<div className={styles.field}>
-										<label htmlFor="add-type" className={styles.fieldLabel}>Type</label>
+										<label htmlFor='add-type' className={styles.fieldLabel}>
+											Type
+										</label>
 										<select
-											id="add-type"
+											id='add-type'
 											className={styles.select}
 											value={addForm.type}
-											onChange={e => setAddForm(f => ({ ...f, type: e.target.value as RuleType }))}
+											onChange={(e) =>
+												setAddForm((f) => ({
+													...f,
+													type: e.target.value as RuleType,
+												}))
+											}
 											disabled={addSubmitting}
 										>
-											<option value="deny">Blocklist</option>
-											<option value="allow">Allowlist</option>
+											<option value='deny'>Blocklist</option>
+											<option value='allow'>Allowlist</option>
 										</select>
 									</div>
 
 									<div className={styles.field}>
-										<label htmlFor="add-kind" className={styles.fieldLabel}>Kind</label>
+										<label htmlFor='add-kind' className={styles.fieldLabel}>
+											Kind
+										</label>
 										<select
-											id="add-kind"
+											id='add-kind'
 											className={styles.select}
 											value={addForm.kind}
-											onChange={e => setAddForm(f => ({ ...f, kind: e.target.value as RuleKind }))}
+											onChange={(e) =>
+												setAddForm((f) => ({
+													...f,
+													kind: e.target.value as RuleKind,
+												}))
+											}
 											disabled={addSubmitting}
 										>
-											<option value="exact">Exact</option>
-											<option value="regex">Regex</option>
+											<option value='exact'>Exact</option>
+											<option value='regex'>Regex</option>
 										</select>
 									</div>
 								</div>
 
 								<div className={styles.field}>
-									<label htmlFor="add-comment" className={styles.fieldLabel}>
+									<label htmlFor='add-comment' className={styles.fieldLabel}>
 										Comment
 										<span className={styles.fieldHint}>(optional)</span>
 									</label>
 									<input
-										id="add-comment"
-										type="text"
+										id='add-comment'
+										type='text'
 										className={styles.input}
-										placeholder="e.g. Added manually"
+										placeholder='e.g. Added manually'
 										value={addForm.comment}
-										onChange={e => setAddForm(f => ({ ...f, comment: e.target.value }))}
+										onChange={(e) =>
+											setAddForm((f) => ({ ...f, comment: e.target.value }))
+										}
 										disabled={addSubmitting}
 									/>
 								</div>
@@ -228,24 +270,30 @@ export function Domains() {
 
 								<div className={styles.dialogActions}>
 									<Dialog.Close asChild>
-										<button type="button" className={styles.cancelBtn} disabled={addSubmitting}>
+										<button
+											type='button'
+											className={styles.cancelBtn}
+											disabled={addSubmitting}
+										>
 											Cancel
 										</button>
 									</Dialog.Close>
 									<button
-										type="button"
+										type='button'
 										className={styles.submitBtn}
 										onClick={handleAdd}
 										disabled={addSubmitting || addForm.domains.trim() === ''}
 										aria-busy={addSubmitting}
 									>
-										{addSubmitting ? <RefreshCw size={15} className={styles.spin} /> : null}
+										{addSubmitting ? (
+											<RefreshCw size={15} className={styles.spin} />
+										) : null}
 										Add
 									</button>
 								</div>
 
 								<Dialog.Close asChild>
-									<button className={styles.dialogClose} aria-label="Close">
+									<button className={styles.dialogClose} aria-label='Close'>
 										<X size={18} />
 									</button>
 								</Dialog.Close>
@@ -277,7 +325,8 @@ export function Domains() {
 				<>
 					<div className={styles.tableInfo}>
 						{filtered.length} {filtered.length === 1 ? 'rule' : 'rules'}
-						{typeFilter !== 'all' && ` in ${typeFilter === 'allow' ? 'allowlist' : 'blocklist'}`}
+						{typeFilter !== 'all' &&
+							` in ${typeFilter === 'allow' ? 'allowlist' : 'blocklist'}`}
 					</div>
 					<div className={styles.tableWrap}>
 						<table className={styles.table}>
@@ -288,58 +337,79 @@ export function Domains() {
 									<th>Kind</th>
 									<th>Nodes</th>
 									<th>Comment</th>
-									<th aria-label="Actions" />
+									<th aria-label='Actions' />
 								</tr>
 							</thead>
 							<tbody>
-								{filtered.map(rule => {
+								{filtered.map((rule) => {
 									const partial = rule.nodeIds.length < rule.totalNodes;
 									const confirming = removeConfirm === rule.key;
 									const isRemoving = removing === rule.key;
 
 									const missingNodeIds = Array.from(nodeNames.keys()).filter(
-										id => !rule.nodeIds.includes(id),
+										(id) => !rule.nodeIds.includes(id),
 									);
 
 									return (
 										<tr key={rule.key} className={styles.row}>
 											<td className={styles.domainCell}>{rule.domain}</td>
 											<td>
-												<span className={styles.typeBadge} data-type={rule.type}>
+												<span
+													className={styles.typeBadge}
+													data-type={rule.type}
+												>
 													{rule.type === 'allow' ? 'Allow' : 'Block'}
 												</span>
 											</td>
 											<td>
-												<span className={styles.kindBadge}>{rule.kind}</span>
+												<span className={styles.kindBadge}>
+													{rule.kind}
+												</span>
 											</td>
 											<td>
 												<span
 													className={styles.nodesBadge}
 													data-partial={partial || undefined}
-													title={partial
-														? `Missing from: ${missingNodeIds.map(id => nodeNames.get(id) ?? id).join(', ')}`
-														: `Present on all ${rule.totalNodes} node(s)`}
+													title={
+														partial
+															? `Missing from: ${missingNodeIds.map((id) => nodeNames.get(id) ?? id).join(', ')}`
+															: `Present on all ${rule.totalNodes} node(s)`
+													}
 												>
 													{rule.nodeIds.length}/{rule.totalNodes}
 												</span>
 											</td>
-											<td className={styles.commentCell}>{rule.comment || '—'}</td>
+											<td className={styles.commentCell}>
+												{rule.comment || '—'}
+											</td>
 											<td className={styles.actionCell}>
 												{confirming ? (
 													<div className={styles.confirmRow}>
-														<span className={styles.confirmText}>Remove?</span>
+														<span className={styles.confirmText}>
+															Remove?
+														</span>
 														<button
-															type="button"
+															type='button'
 															className={styles.confirmYesBtn}
 															onClick={() => handleRemove(rule)}
 															disabled={isRemoving}
 														>
-															{isRemoving ? <RefreshCw size={13} className={styles.spin} /> : 'Yes'}
+															{isRemoving ? (
+																<RefreshCw
+																	size={13}
+																	className={styles.spin}
+																/>
+															) : (
+																'Yes'
+															)}
 														</button>
 														<button
-															type="button"
+															type='button'
 															className={styles.confirmNoBtn}
-															onClick={() => { setRemoveConfirm(null); setRemoveError(null); }}
+															onClick={() => {
+																setRemoveConfirm(null);
+																setRemoveError(null);
+															}}
 															disabled={isRemoving}
 														>
 															No
@@ -347,7 +417,7 @@ export function Domains() {
 													</div>
 												) : (
 													<button
-														type="button"
+														type='button'
 														className={styles.removeBtn}
 														onClick={() => setRemoveConfirm(rule.key)}
 														disabled={isRemoving}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -10,8 +10,10 @@ export function Home() {
 
 	return (
 		<div className={styles.page}>
-			<section className={styles.section} aria-labelledby="cluster-status-heading">
-				<h2 id="cluster-status-heading" className={styles.sectionTitle}>Cluster Status</h2>
+			<section className={styles.section} aria-labelledby='cluster-status-heading'>
+				<h2 id='cluster-status-heading' className={styles.sectionTitle}>
+					Cluster Status
+				</h2>
 				<div className={styles.summaryCards}>
 					<div className={styles.card}>
 						{blocking !== undefined ? (
@@ -29,41 +31,61 @@ export function Home() {
 							{healthSummary ? (
 								<>
 									{healthSummary.online}
-									<span className={styles.statDenominator}> / {healthSummary.total}</span>
+									<span className={styles.statDenominator}>
+										{' '}
+										/ {healthSummary.total}
+									</span>
 								</>
-							) : '—'}
+							) : (
+								'—'
+							)}
 						</div>
 						<div className={styles.cardSub}>Nodes online</div>
 					</div>
 				</div>
 			</section>
 
-			<section className={styles.section} aria-labelledby="nodes-heading">
-				<h2 id="nodes-heading" className={styles.sectionTitle}>Nodes</h2>
+			<section className={styles.section} aria-labelledby='nodes-heading'>
+				<h2 id='nodes-heading' className={styles.sectionTitle}>
+					Nodes
+				</h2>
 				{nodes.length === 0 ? (
 					<p className={styles.empty}>No nodes configured.</p>
 				) : (
 					<div className={styles.nodeGrid}>
 						{nodes.map(({ id, node, health }) => (
-							<div key={id} className={styles.nodeCard} data-status={health?.status ?? 'unknown'}>
+							<div
+								key={id}
+								className={styles.nodeCard}
+								data-status={health?.status ?? 'unknown'}
+							>
 								<div className={styles.nodeHeader}>
 									<PiholeStatusLight
 										name={node?.name ?? `Node ${id}`}
 										health={health}
 										fresh={healthFresh}
 									/>
-									<span className={styles.nodeName}>{node?.name ?? `Node ${id}`}</span>
+									<span className={styles.nodeName}>
+										{node?.name ?? `Node ${id}`}
+									</span>
 								</div>
 								<dl className={styles.nodeDetails}>
 									<div className={styles.nodeDetail}>
 										<dt>Status</dt>
-										<dd data-status={health?.status ?? 'unknown'} className={styles.nodeStatusValue}>
+										<dd
+											data-status={health?.status ?? 'unknown'}
+											className={styles.nodeStatusValue}
+										>
 											{health?.status ?? 'unknown'}
 										</dd>
 									</div>
 									<div className={styles.nodeDetail}>
 										<dt>Latency</dt>
-										<dd>{health?.latencyMs != null ? `${health.latencyMs}ms` : '—'}</dd>
+										<dd>
+											{health?.latencyMs != null
+												? `${health.latencyMs}ms`
+												: '—'}
+										</dd>
 									</div>
 								</dl>
 								{health?.lastErr && (

--- a/frontend/src/providers/ClusterOverviewProvider.tsx
+++ b/frontend/src/providers/ClusterOverviewProvider.tsx
@@ -1,9 +1,4 @@
-import {
-	createContext,
-	useContext,
-	useMemo,
-	ReactNode,
-} from 'react';
+import { createContext, useContext, useMemo, ReactNode } from 'react';
 import { useClusterHealth } from '@/hooks/useClusterHealth';
 import { useClusterBlocking } from '@/hooks/useClusterBlocking';
 import type { PiholeNodeRef } from '@/types/pihole';
@@ -23,7 +18,9 @@ export type ClusterOverviewValue = {
 	setOptimisticEnabled: ReturnType<typeof useClusterBlocking>['setOptimisticEnabled'];
 	setOptimisticNodeEnabled: ReturnType<typeof useClusterBlocking>['setOptimisticNodeEnabled'];
 	applyOptimisticNodeDisable: ReturnType<typeof useClusterBlocking>['applyOptimisticNodeDisable'];
-	applyOptimisticClusterDisable: ReturnType<typeof useClusterBlocking>['applyOptimisticClusterDisable'];
+	applyOptimisticClusterDisable: ReturnType<
+		typeof useClusterBlocking
+	>['applyOptimisticClusterDisable'];
 	requestedNodeDisplay: ReturnType<typeof useClusterBlocking>['requestedNodeDisplay'];
 	clearRequestedNodeDisplay: ReturnType<typeof useClusterBlocking>['clearRequestedNodeDisplay'];
 	requestedTimer: ReturnType<typeof useClusterBlocking>['requestedTimer'];
@@ -108,9 +105,7 @@ export function ClusterOverviewProvider({ children }: { children: ReactNode }) {
 	]);
 
 	return (
-		<ClusterOverviewContext.Provider value={value}>
-			{children}
-		</ClusterOverviewContext.Provider>
+		<ClusterOverviewContext.Provider value={value}>{children}</ClusterOverviewContext.Provider>
 	);
 }
 

--- a/frontend/src/types/domainrule.ts
+++ b/frontend/src/types/domainrule.ts
@@ -36,18 +36,21 @@ export type ListDomainRulesResponse = {
 };
 
 export type AddDomainRuleResponse = {
-	nodes: Record<string, {
-		node: PiholeNodeRef;
-		result: {
-			domains: DomainRule[];
-			processed: {
-				success: { item: string }[];
-				errors: { item: string; error: string }[];
+	nodes: Record<
+		string,
+		{
+			node: PiholeNodeRef;
+			result: {
+				domains: DomainRule[];
+				processed: {
+					success: { item: string }[];
+					errors: { item: string; error: string }[];
+				};
+				tookMs: number;
 			};
-			tookMs: number;
-		};
-		error?: string;
-	}>;
+			error?: string;
+		}
+	>;
 };
 
 export type RemoveDomainRuleResponse = {
@@ -57,11 +60,14 @@ export type RemoveDomainRuleResponse = {
 		failed: number;
 		errors: number;
 	};
-	nodes: Record<string, {
-		node: PiholeNodeRef;
-		removed: boolean;
-		error?: string;
-	}>;
+	nodes: Record<
+		string,
+		{
+			node: PiholeNodeRef;
+			removed: boolean;
+			error?: string;
+		}
+	>;
 };
 
 export type ConsolidatedRule = {

--- a/frontend/src/utils/blockingStatus.ts
+++ b/frontend/src/utils/blockingStatus.ts
@@ -3,11 +3,11 @@ import { Shield, ShieldOff, ShieldHalf, AlertTriangle } from 'lucide-react';
 import type { ClusterBlockingSummary } from '@/types/blocking';
 
 export type BlockingDisplayVariant =
-	| 'enabled'       // green shield – blocking
-	| 'disabled'      // blue shield-off – not blocking (valid)
-	| 'mixed'         // blue caution – partial valid state
-	| 'mixed-errors'  // yellow caution – partial due to API errors
-	| 'degraded';    // red caution – all nodes error
+	| 'enabled' // green shield – blocking
+	| 'disabled' // blue shield-off – not blocking (valid)
+	| 'mixed' // blue caution – partial valid state
+	| 'mixed-errors' // yellow caution – partial due to API errors
+	| 'degraded'; // red caution – all nodes error
 
 export type BlockingDisplayState = {
 	icon: LucideIcon;


### PR DESCRIPTION
## Summary
- Add CSRF middleware (`middleware/csrf.go`) validating `X-CSRF-Token` header matches `csrf_token` cookie on all mutating requests; safe methods exempt
- `SessionCookieFactory.MakeCSRF()` — creates the CSRF cookie with `HttpOnly=false` so JS can read it
- Set CSRF cookie alongside session cookie on login and first-run setup; clear on logout
- Frontend `client.ts` reads `csrf_token` cookie and attaches it as `X-CSRF-Token` on all mutating API calls

Closes #13

## Test plan
- [ ] Login → check `csrf_token` cookie is set in browser DevTools (not HttpOnly)
- [ ] Mutating request (e.g. block/allow domain) succeeds with CSRF header present
- [ ] Request without CSRF header (or mismatched token) returns 403
- [ ] Logout clears `csrf_token` cookie
- [ ] Setup flow (first-run user creation) → CSRF cookie set after

🤖 Generated with [Claude Code](https://claude.com/claude-code)