### PR TITLE
feat: add node parity sync for domain rules

### DIFF
--- a/backend/internal/domain/domainrule.go
+++ b/backend/internal/domain/domainrule.go
@@ -76,3 +76,15 @@ type AddDomainRulesResult struct {
 	Processed DomainProcessed
 	Took      time.Duration
 }
+
+type SyncDomainRuleCommand struct {
+	Type    RuleType
+	Kind    RuleKind
+	Domain  string
+	Comment *string
+}
+
+type SyncDomainRuleNodeResult struct {
+	AlreadyPresent bool
+	Added          bool
+}

--- a/backend/internal/http/api/v1/domainrule_dto.go
+++ b/backend/internal/http/api/v1/domainrule_dto.go
@@ -115,6 +115,34 @@ func toProcessedDTO(p domain.DomainProcessed) domainProcessedDTO {
 	return out
 }
 
+// Sync parity
+
+type syncDomainRuleRequestDTO struct {
+	Type    string  `json:"type"`
+	Kind    string  `json:"kind"`
+	Domain  string  `json:"domain"`
+	Comment *string `json:"comment,omitempty"`
+}
+
+type syncDomainRuleResponseDTO struct {
+	Summary syncSummaryDTO                  `json:"summary"`
+	Nodes   map[int64]syncDomainRuleNodeDTO `json:"nodes"`
+}
+
+type syncSummaryDTO struct {
+	TotalNodes          int `json:"totalNodes"`
+	SyncedNodes         int `json:"syncedNodes"`
+	AlreadyPresentNodes int `json:"alreadyPresentNodes"`
+	FailedNodes         int `json:"failedNodes"`
+}
+
+type syncDomainRuleNodeDTO struct {
+	Node           piholeNodeRefDTO `json:"node"`
+	AlreadyPresent bool             `json:"alreadyPresent"`
+	Added          bool             `json:"added"`
+	Error          string           `json:"error,omitempty"`
+}
+
 // Remove domain
 
 type removeDomainRuleResponseDTO struct {

--- a/backend/internal/http/api/v1/domainrule_handlers.go
+++ b/backend/internal/http/api/v1/domainrule_handlers.go
@@ -23,6 +23,8 @@ func registerDomainRules(r chi.Router, d Deps) {
 		// Write
 		r.Post("/type/{type}/kind/{kind}", domainRuleAddDomainRule(d))
 		r.Delete("/type/{type}/kind/{kind}/domain/{domain}", domainRuleRemoveDomainRule(d))
+		// Parity sync
+		r.Post("/parity/sync", domainRuleSyncParityRule(d))
 	})
 }
 
@@ -264,6 +266,76 @@ func domainRuleRemoveDomainRule(d Deps) http.HandlerFunc {
 			Removed: removed,
 			Failed:  total - removed,
 			Errors:  errors,
+		}
+
+		transport.WriteJSON(w, http.StatusOK, dto)
+	}
+}
+
+func domainRuleSyncParityRule(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body syncDomainRuleRequestDTO
+		if err := transport.DecodeJSONBody(w, r, &body, 1<<20); err != nil {
+			d.Logger.Error().Err(err).Msg("invalid JSON body")
+			transport.WriteErr(w, err)
+			return
+		}
+
+		ruleType, ok := parseRuleType(body.Type)
+		if !ok {
+			transport.WriteBadRequestErr(w, "bad \"type\"", errors.New("bad \"type\""))
+			return
+		}
+		ruleKind, ok := parseRuleKind(body.Kind)
+		if !ok {
+			transport.WriteBadRequestErr(w, "bad \"kind\"", errors.New("bad \"kind\""))
+			return
+		}
+		if body.Domain == "" {
+			transport.WriteBadRequestErr(w, "\"domain\" is required", errors.New("\"domain\" is required"))
+			return
+		}
+
+		cmd := domain.SyncDomainRuleCommand{
+			Type:    ruleType,
+			Kind:    ruleKind,
+			Domain:  body.Domain,
+			Comment: body.Comment,
+		}
+
+		logger := d.Logger.With().Str("type", string(ruleType)).Str("kind", string(ruleKind)).Str("domain", body.Domain).Logger()
+		logger.Debug().Msg("syncing domain rule parity")
+
+		results := d.DomainRuleService.SyncRule(r.Context(), cmd)
+
+		dto := syncDomainRuleResponseDTO{
+			Nodes: make(map[int64]syncDomainRuleNodeDTO, len(results)),
+		}
+		for id, nr := range results {
+			node := syncDomainRuleNodeDTO{
+				Node: piholeNodeRefDTO{
+					Id:   nr.PiholeNode.Id,
+					Name: nr.PiholeNode.Name,
+					Host: nr.PiholeNode.Host,
+				},
+			}
+			if nr.Error != nil {
+				node.Error = nr.Error.Error()
+			}
+			if nr.Response != nil {
+				node.AlreadyPresent = nr.Response.AlreadyPresent
+				node.Added = nr.Response.Added
+			}
+			dto.Nodes[id] = node
+			dto.Summary.TotalNodes++
+			switch {
+			case nr.Response != nil && nr.Response.AlreadyPresent:
+				dto.Summary.AlreadyPresentNodes++
+			case nr.Success:
+				dto.Summary.SyncedNodes++
+			default:
+				dto.Summary.FailedNodes++
+			}
 		}
 
 		transport.WriteJSON(w, http.StatusOK, dto)

--- a/backend/internal/http/api/v1/interface.go
+++ b/backend/internal/http/api/v1/interface.go
@@ -27,6 +27,7 @@ type domainRuleService interface {
 	List(ctx context.Context, q domain.ListDomainRulesQuery) map[int64]*domain.NodeResult[*domain.DomainRuleSet]
 	Add(ctx context.Context, cmd domain.AddDomainRulesCommand) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult]
 	Remove(ctx context.Context, cmd domain.RemoveDomainRuleCommand) map[int64]*domain.NodeResult[struct{}]
+	SyncRule(ctx context.Context, cmd domain.SyncDomainRuleCommand) map[int64]*domain.NodeResult[*domain.SyncDomainRuleNodeResult]
 }
 
 type healthService interface {

--- a/backend/internal/pihole/cluster.go
+++ b/backend/internal/pihole/cluster.go
@@ -261,6 +261,74 @@ func (c *Cluster) AddDomainRule(ctx context.Context, cmd domain.AddDomainRulesCo
 	return out
 }
 
+func (c *Cluster) AddDomainRuleToNodes(ctx context.Context, cmd domain.AddDomainRulesCommand, nodeIDs []int64) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult] {
+	c.logger.Debug().Msg("adding domain rule to specific pihole nodes")
+
+	c.rw.RLock()
+	targets := make(map[int64]clientPort, len(nodeIDs))
+	for _, id := range nodeIDs {
+		if cl, ok := c.clients[id]; ok {
+			targets[id] = cl
+		}
+	}
+	c.rw.RUnlock()
+
+	results := make(map[int64]*domain.NodeResult[*domain.AddDomainRulesResult], len(targets))
+	if len(targets) == 0 {
+		return results
+	}
+
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	for id, cl := range targets {
+		id, cl := id, cl
+		g.Go(func() error {
+			defer func() {
+				if r := recover(); r != nil {
+					c.logger.Error().Interface("panic", r).Int64("id", id).Msg("worker panic recovered")
+				}
+			}()
+
+			nodeTimeout := 3 * time.Second
+			if dl, ok := gctx.Deadline(); ok {
+				if remaining := time.Until(dl) / 2; remaining < nodeTimeout {
+					nodeTimeout = remaining
+				}
+			}
+			nodeCtx, cancel := context.WithTimeout(gctx, nodeTimeout)
+			defer cancel()
+
+			resp, err := cl.AddDomainRule(nodeCtx, cmd)
+			if err != nil {
+				err = mapClientErr(err)
+			}
+
+			node := cl.GetNodeInfo(nodeCtx)
+
+			mu.Lock()
+			results[id] = &domain.NodeResult[*domain.AddDomainRulesResult]{
+				PiholeNode: node,
+				Success:    err == nil,
+				Error:      err,
+				Response:   resp,
+			}
+			mu.Unlock()
+
+			if err != nil && !errors.Is(err, context.Canceled) {
+				c.logger.Warn().Int64("id", id).Str("error", util.ErrorString(err)).Msg("selective fanout: node operation failed")
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		if errors.Is(err, context.Canceled) {
+			c.logger.Warn().Err(err).Msg("selective fanout aborted")
+		}
+	}
+	return results
+}
+
 func (c *Cluster) RemoveDomainRule(ctx context.Context, cmd domain.RemoveDomainRuleCommand) map[int64]*domain.NodeResult[struct{}] {
 	c.logger.Debug().Msg("removing domain rule from all pihole nodes")
 	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (struct{}, error) {

--- a/backend/internal/service/domainrule/interface.go
+++ b/backend/internal/service/domainrule/interface.go
@@ -9,5 +9,6 @@ import (
 type cluster interface {
 	ListDomainRules(ctx context.Context, q domain.ListDomainRulesQuery) map[int64]*domain.NodeResult[*domain.DomainRuleSet]
 	AddDomainRule(ctx context.Context, cmd domain.AddDomainRulesCommand) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult]
+	AddDomainRuleToNodes(ctx context.Context, cmd domain.AddDomainRulesCommand, nodeIDs []int64) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult]
 	RemoveDomainRule(ctx context.Context, cmd domain.RemoveDomainRuleCommand) map[int64]*domain.NodeResult[struct{}]
 }

--- a/backend/internal/service/domainrule/service.go
+++ b/backend/internal/service/domainrule/service.go
@@ -27,3 +27,70 @@ func (s *Service) Add(ctx context.Context, cmd domain.AddDomainRulesCommand) map
 func (s *Service) Remove(ctx context.Context, cmd domain.RemoveDomainRuleCommand) map[int64]*domain.NodeResult[struct{}] {
 	return s.cluster.RemoveDomainRule(ctx, cmd)
 }
+
+func (s *Service) SyncRule(ctx context.Context, cmd domain.SyncDomainRuleCommand) map[int64]*domain.NodeResult[*domain.SyncDomainRuleNodeResult] {
+	ruleType := cmd.Type
+	ruleKind := cmd.Kind
+	listResults := s.cluster.ListDomainRules(ctx, domain.ListDomainRulesQuery{
+		Type: &ruleType,
+		Kind: &ruleKind,
+	})
+
+	type entry struct {
+		nr      *domain.NodeResult[*domain.DomainRuleSet]
+		present bool
+	}
+	entries := make(map[int64]entry, len(listResults))
+	missingNodeIDs := make([]int64, 0)
+
+	for nodeID, nr := range listResults {
+		present := false
+		if nr.Success && nr.Response != nil {
+			for _, r := range nr.Response.Rules {
+				if r.Domain == cmd.Domain {
+					present = true
+					break
+				}
+			}
+		}
+		entries[nodeID] = entry{nr: nr, present: present}
+		if !present {
+			missingNodeIDs = append(missingNodeIDs, nodeID)
+		}
+	}
+
+	out := make(map[int64]*domain.NodeResult[*domain.SyncDomainRuleNodeResult], len(listResults))
+
+	for nodeID, e := range entries {
+		if e.present {
+			out[nodeID] = &domain.NodeResult[*domain.SyncDomainRuleNodeResult]{
+				PiholeNode: e.nr.PiholeNode,
+				Success:    true,
+				Response:   &domain.SyncDomainRuleNodeResult{AlreadyPresent: true},
+			}
+		}
+	}
+
+	if len(missingNodeIDs) == 0 {
+		return out
+	}
+
+	addCmd := domain.AddDomainRulesCommand{
+		Type:    cmd.Type,
+		Kind:    cmd.Kind,
+		Domains: []string{cmd.Domain},
+		Comment: cmd.Comment,
+	}
+	addResults := s.cluster.AddDomainRuleToNodes(ctx, addCmd, missingNodeIDs)
+
+	for nodeID, nr := range addResults {
+		out[nodeID] = &domain.NodeResult[*domain.SyncDomainRuleNodeResult]{
+			PiholeNode: nr.PiholeNode,
+			Success:    nr.Success,
+			Error:      nr.Error,
+			Response:   &domain.SyncDomainRuleNodeResult{AlreadyPresent: false, Added: nr.Success},
+		}
+	}
+
+	return out
+}

--- a/frontend/src/lib/api/domainrules.ts
+++ b/frontend/src/lib/api/domainrules.ts
@@ -3,6 +3,7 @@ import type {
 	ListDomainRulesResponse,
 	AddDomainRuleResponse,
 	RemoveDomainRuleResponse,
+	SyncDomainRuleResponse,
 	RuleType,
 	RuleKind,
 } from '@/types/domainrule';
@@ -32,4 +33,16 @@ export async function removeDomainRule(
 		`/domain/type/${type}/kind/${kind}/domain/${encodeURIComponent(domain)}`,
 		{ method: 'DELETE' },
 	);
+}
+
+export async function syncDomainRule(
+	type: RuleType,
+	kind: RuleKind,
+	domain: string,
+	comment?: string,
+): Promise<SyncDomainRuleResponse> {
+	return apiV1Fetch<SyncDomainRuleResponse>('/domain/parity/sync', {
+		method: 'POST',
+		body: JSON.stringify({ type, kind, domain, comment: comment || undefined }),
+	});
 }

--- a/frontend/src/pages/Domains.module.scss
+++ b/frontend/src/pages/Domains.module.scss
@@ -221,6 +221,80 @@
 	}
 }
 
+// ---- Parity banner ----
+
+.parityBanner {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.6rem 1rem;
+	margin-bottom: 1rem;
+	background: color-mix(in oklab, var(--accent-warn) 10%, transparent);
+	border: 1px solid color-mix(in oklab, var(--accent-warn) 30%, transparent);
+	border-radius: var(--input-radius);
+	color: var(--accent-warn);
+	font-size: 0.875rem;
+}
+
+.syncAllBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.3rem;
+	margin-left: auto;
+	padding: 0.3rem 0.75rem;
+	font-size: 0.8rem;
+	font-weight: 500;
+	background: var(--accent-warn);
+	color: #fff;
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: color-mix(in oklab, var(--accent-warn) 85%, black);
+	}
+
+	&:disabled {
+		opacity: 0.7;
+		cursor: not-allowed;
+	}
+}
+
+// ---- Action cell ----
+
+.actionRow {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	justify-content: flex-end;
+}
+
+.syncBtn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	padding: 0 !important;
+	background: none !important;
+	border: 1px solid transparent;
+	border-radius: var(--border-radius);
+	color: var(--accent-warn) !important;
+	cursor: pointer;
+	transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: color-mix(in oklab, var(--accent-warn) 10%, transparent) !important;
+		border-color: var(--accent-warn);
+	}
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+}
+
 // ---- Remove flow ----
 
 .removeBtn {

--- a/frontend/src/pages/Domains.tsx
+++ b/frontend/src/pages/Domains.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Plus, Trash2, RefreshCw, X } from 'lucide-react';
-import { listDomainRules, addDomainRule, removeDomainRule } from '@/lib/api/domainrules';
+import { Plus, Trash2, RefreshCw, X, GitMerge } from 'lucide-react';
+import {
+	listDomainRules,
+	addDomainRule,
+	removeDomainRule,
+	syncDomainRule,
+} from '@/lib/api/domainrules';
 import type {
 	ConsolidatedRule,
 	RuleType,
@@ -71,6 +76,10 @@ export function Domains() {
 	const [removing, setRemoving] = useState<string | null>(null);
 	const [removeError, setRemoveError] = useState<string | null>(null);
 
+	const [syncing, setSyncing] = useState<string | null>(null);
+	const [syncingAll, setSyncingAll] = useState(false);
+	const [syncError, setSyncError] = useState<string | null>(null);
+
 	const fetchRules = useCallback(async () => {
 		setLoading(true);
 		setError(null);
@@ -132,7 +141,39 @@ export function Domains() {
 		}
 	}
 
+	async function handleSync(rule: ConsolidatedRule) {
+		setSyncError(null);
+		setSyncing(rule.key);
+		try {
+			await syncDomainRule(rule.type, rule.kind, rule.domain, rule.comment ?? undefined);
+			await fetchRules();
+		} catch (err) {
+			setSyncError(err instanceof Error ? err.message : 'Failed to sync rule');
+		} finally {
+			setSyncing(null);
+		}
+	}
+
+	async function handleSyncAll() {
+		setSyncError(null);
+		setSyncingAll(true);
+		try {
+			const partialRules = rules.filter((r) => r.nodeIds.length < r.totalNodes);
+			await Promise.all(
+				partialRules.map((r) =>
+					syncDomainRule(r.type, r.kind, r.domain, r.comment ?? undefined),
+				),
+			);
+			await fetchRules();
+		} catch (err) {
+			setSyncError(err instanceof Error ? err.message : 'Failed to sync rules');
+		} finally {
+			setSyncingAll(false);
+		}
+	}
+
 	const filtered = typeFilter === 'all' ? rules : rules.filter((r) => r.type === typeFilter);
+	const partialCount = rules.filter((r) => r.nodeIds.length < r.totalNodes).length;
 
 	return (
 		<div className={styles.page}>
@@ -305,6 +346,27 @@ export function Domains() {
 
 			{error && <div className={styles.error}>{error}</div>}
 			{removeError && <div className={styles.error}>{removeError}</div>}
+			{syncError && <div className={styles.error}>{syncError}</div>}
+
+			{!loading && !error && partialCount > 0 && (
+				<div className={styles.parityBanner}>
+					<GitMerge size={15} />
+					<span>
+						{partialCount} {partialCount === 1 ? 'rule' : 'rules'} with partial node
+						coverage
+					</span>
+					<button
+						type='button'
+						className={styles.syncAllBtn}
+						onClick={handleSyncAll}
+						disabled={syncingAll || loading}
+						aria-busy={syncingAll}
+					>
+						{syncingAll ? <RefreshCw size={13} className={styles.spin} /> : null}
+						Sync all
+					</button>
+				</div>
+			)}
 
 			{loading && rules.length === 0 && (
 				<div className={styles.loadingState}>
@@ -416,15 +478,41 @@ export function Domains() {
 														</button>
 													</div>
 												) : (
-													<button
-														type='button'
-														className={styles.removeBtn}
-														onClick={() => setRemoveConfirm(rule.key)}
-														disabled={isRemoving}
-														aria-label={`Remove ${rule.domain}`}
-													>
-														<Trash2 size={15} />
-													</button>
+													<div className={styles.actionRow}>
+														{partial && (
+															<button
+																type='button'
+																className={styles.syncBtn}
+																onClick={() => handleSync(rule)}
+																disabled={
+																	syncing === rule.key ||
+																	syncingAll
+																}
+																aria-label={`Sync ${rule.domain} to all nodes`}
+																title='Sync to missing nodes'
+															>
+																{syncing === rule.key ? (
+																	<RefreshCw
+																		size={13}
+																		className={styles.spin}
+																	/>
+																) : (
+																	<GitMerge size={14} />
+																)}
+															</button>
+														)}
+														<button
+															type='button'
+															className={styles.removeBtn}
+															onClick={() =>
+																setRemoveConfirm(rule.key)
+															}
+															disabled={isRemoving}
+															aria-label={`Remove ${rule.domain}`}
+														>
+															<Trash2 size={15} />
+														</button>
+													</div>
 												)}
 											</td>
 										</tr>

--- a/frontend/src/types/domainrule.ts
+++ b/frontend/src/types/domainrule.ts
@@ -80,3 +80,21 @@ export type ConsolidatedRule = {
 	nodeIds: number[];
 	totalNodes: number;
 };
+
+export type SyncDomainRuleResponse = {
+	summary: {
+		totalNodes: number;
+		syncedNodes: number;
+		alreadyPresentNodes: number;
+		failedNodes: number;
+	};
+	nodes: Record<
+		string,
+		{
+			node: PiholeNodeRef;
+			alreadyPresent: boolean;
+			added: boolean;
+			error?: string;
+		}
+	>;
+};


### PR DESCRIPTION
## Summary

- Adds amber parity banner to the Domains page when any rules have partial node coverage (present on some nodes but not all)
- Per-row **Sync** button (GitMerge icon) for partial rules — adds the rule only to nodes that are missing it
- **Sync All** button in the banner syncs all partial rules concurrently
- New backend endpoint `POST /api/v1/domain/parity/sync` with selective fan-out: lists rules cluster-wide, identifies missing nodes, adds to them only (avoids duplicate-add issues since Pi-hole returns 200 not 201 for existing rules)

## Test plan

- [ ] Add a domain rule while one node is offline → rule will show 1/2 or 1/3 with amber badge and parity banner
- [ ] Click Sync button on the partial row → banner disappears, badge turns green 2/2 or 3/3
- [ ] Click Sync All → all partial rules sync
- [ ] Rules already present on all nodes: no banner, no sync button

🤖 Generated with [Claude Code](https://claude.com/claude-code)