### PR TITLE
feat: add rollback for domain rule audit entries

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/auto-dns/pihole-cluster-admin/internal/http/server"
 	"github.com/auto-dns/pihole-cluster-admin/internal/pihole"
 	"github.com/auto-dns/pihole-cluster-admin/internal/realtime"
+	auditlogsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/auditlog"
 	authsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/auth"
 	clusterblockingsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/clusterblocking"
 	domainrulesvc "github.com/auto-dns/pihole-cluster-admin/internal/service/domainrule"
@@ -65,6 +66,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 		logger.Error().Err(err).Msg("error initializing database")
 		return nil, err
 	}
+	auditLogStore := store.NewAuditLogStore(db, logger)
 	initializationStatusStore := store.NewInitializationStore(db, logger)
 	piholeStore := store.NewPiholeStore(db, cfg.EncryptionKey, logger)
 	sessionStore := store.NewSessionStore(db, logger)
@@ -89,9 +91,10 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	cookieFactory := cookies.NewSessionCookieFactory(cfg.Server.Session)
 
 	// Router
+	auditLogService := auditlogsvc.NewService(auditLogStore, logger)
 	authService := authsvc.NewService(userStore, sessionManager, logger)
-	clusterBlockingService := clusterblockingsvc.NewService(cluster, broker, cfg.Publishers.ClusterBlocking, logger)
-	domainRuleService := domainrulesvc.NewService(cluster)
+	clusterBlockingService := clusterblockingsvc.NewService(cluster, broker, auditLogService, cfg.Publishers.ClusterBlocking, logger)
+	domainRuleService := domainrulesvc.NewService(cluster, auditLogService)
 	eventsService := eventssvc.NewService(broker, logger)
 	healthService := healthsvc.NewService(broker, cluster, cfg.Publishers.Health, logger)
 	piholeService := piholesvc.NewService(cluster, piholeStore, logger)
@@ -101,6 +104,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	// Middleware
 	requireAuthMiddleware := middleware.RequireAuth(middleware.AuthDeps{
 		Sessions: sessionManager,
+		Users:    userStore,
 		Cfg:      cfg.Server.Session,
 		Logger:   logger,
 	})
@@ -138,6 +142,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	apiV1 := chi.NewRouter()
 	apiRouter.Mount("/v1", apiV1)
 	v1.RegisterAPIV1(apiV1, v1.Deps{
+		AuditLogService:        auditLogService,
 		AuthService:            authService,
 		ClusterBlockingService: clusterBlockingService,
 		DomainRuleService:      domainRuleService,

--- a/backend/internal/domain/auditlog.go
+++ b/backend/internal/domain/auditlog.go
@@ -1,0 +1,52 @@
+package domain
+
+import "time"
+
+type AuditAction string
+
+const (
+	AuditActionAddDomainRule      AuditAction = "add_domain_rule"
+	AuditActionRemoveDomainRule   AuditAction = "remove_domain_rule"
+	AuditActionSetClusterBlocking AuditAction = "set_cluster_blocking"
+	AuditActionSetNodeBlocking    AuditAction = "set_node_blocking"
+)
+
+type AuditNodeResult struct {
+	NodeId   int64
+	NodeName string
+	Success  bool
+	Error    string
+}
+
+type AuditEntry struct {
+	Id              int64
+	Actor           string
+	Action          AuditAction
+	TargetDomain    *string
+	RuleType        *string
+	RuleKind        *string
+	BlockingEnabled *bool
+	BlockingTimer   *int
+	TargetNodeId    *int64
+	TargetNodeName  *string
+	NodeResults     []AuditNodeResult
+	CreatedAt       time.Time
+}
+
+type CreateAuditEntryParams struct {
+	Actor           string
+	Action          AuditAction
+	TargetDomain    *string
+	RuleType        *string
+	RuleKind        *string
+	BlockingEnabled *bool
+	BlockingTimer   *int
+	TargetNodeId    *int64
+	TargetNodeName  *string
+	NodeResults     []AuditNodeResult
+}
+
+type ListAuditEntriesQuery struct {
+	Limit  int
+	Offset int
+}

--- a/backend/internal/http/api/v1/auditlog_dto.go
+++ b/backend/internal/http/api/v1/auditlog_dto.go
@@ -1,0 +1,62 @@
+package v1
+
+import (
+	"time"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+)
+
+type auditEntryDTO struct {
+	Id              int64             `json:"id"`
+	Actor           string            `json:"actor"`
+	Action          string            `json:"action"`
+	TargetDomain    *string           `json:"targetDomain,omitempty"`
+	RuleType        *string           `json:"ruleType,omitempty"`
+	RuleKind        *string           `json:"ruleKind,omitempty"`
+	BlockingEnabled *bool             `json:"blockingEnabled,omitempty"`
+	BlockingTimer   *int              `json:"blockingTimer,omitempty"`
+	TargetNodeId    *int64            `json:"targetNodeId,omitempty"`
+	TargetNodeName  *string           `json:"targetNodeName,omitempty"`
+	NodeResults     []auditNodeResult `json:"nodeResults"`
+	CreatedAt       string            `json:"createdAt"`
+}
+
+type auditNodeResult struct {
+	NodeId   int64  `json:"nodeId"`
+	NodeName string `json:"nodeName"`
+	Success  bool   `json:"success"`
+	Error    string `json:"error,omitempty"`
+}
+
+type listAuditResponseDTO struct {
+	Entries []auditEntryDTO `json:"entries"`
+	Total   int             `json:"total"`
+	Limit   int             `json:"limit"`
+	Offset  int             `json:"offset"`
+}
+
+func toAuditEntryDTO(e *domain.AuditEntry) auditEntryDTO {
+	nodeResults := make([]auditNodeResult, 0, len(e.NodeResults))
+	for _, nr := range e.NodeResults {
+		nodeResults = append(nodeResults, auditNodeResult{
+			NodeId:   nr.NodeId,
+			NodeName: nr.NodeName,
+			Success:  nr.Success,
+			Error:    nr.Error,
+		})
+	}
+	return auditEntryDTO{
+		Id:              e.Id,
+		Actor:           e.Actor,
+		Action:          string(e.Action),
+		TargetDomain:    e.TargetDomain,
+		RuleType:        e.RuleType,
+		RuleKind:        e.RuleKind,
+		BlockingEnabled: e.BlockingEnabled,
+		BlockingTimer:   e.BlockingTimer,
+		TargetNodeId:    e.TargetNodeId,
+		TargetNodeName:  e.TargetNodeName,
+		NodeResults:     nodeResults,
+		CreatedAt:       e.CreatedAt.UTC().Format(time.RFC3339),
+	}
+}

--- a/backend/internal/http/api/v1/auditlog_dto.go
+++ b/backend/internal/http/api/v1/auditlog_dto.go
@@ -35,6 +35,18 @@ type listAuditResponseDTO struct {
 	Offset  int             `json:"offset"`
 }
 
+type rollbackResponseDTO struct {
+	OriginalId int64                   `json:"originalId"`
+	Nodes      []rollbackNodeResultDTO `json:"nodes"`
+}
+
+type rollbackNodeResultDTO struct {
+	NodeId   int64  `json:"nodeId"`
+	NodeName string `json:"nodeName"`
+	Success  bool   `json:"success"`
+	Error    string `json:"error,omitempty"`
+}
+
 func toAuditEntryDTO(e *domain.AuditEntry) auditEntryDTO {
 	nodeResults := make([]auditNodeResult, 0, len(e.NodeResults))
 	for _, nr := range e.NodeResults {

--- a/backend/internal/http/api/v1/auditlog_handlers.go
+++ b/backend/internal/http/api/v1/auditlog_handlers.go
@@ -1,0 +1,55 @@
+package v1
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/http/transport"
+	"github.com/go-chi/chi"
+)
+
+
+func registerAuditLog(r chi.Router, d Deps) {
+	r.Get("/audit", auditLogList(d))
+}
+
+func auditLogList(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		limit := 50
+		offset := 0
+
+		if v := r.URL.Query().Get("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 200 {
+				limit = n
+			}
+		}
+		if v := r.URL.Query().Get("offset"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				offset = n
+			}
+		}
+
+		entries, total, err := d.AuditLogService.List(r.Context(), domain.ListAuditEntriesQuery{
+			Limit:  limit,
+			Offset: offset,
+		})
+		if err != nil {
+			d.Logger.Error().Err(err).Msg("failed to list audit log entries")
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		dtos := make([]auditEntryDTO, 0, len(entries))
+		for _, e := range entries {
+			dtos = append(dtos, toAuditEntryDTO(e))
+		}
+
+		transport.WriteJSON(w, http.StatusOK, listAuditResponseDTO{
+			Entries: dtos,
+			Total:   total,
+			Limit:   limit,
+			Offset:  offset,
+		})
+	}
+}

--- a/backend/internal/http/api/v1/auditlog_handlers.go
+++ b/backend/internal/http/api/v1/auditlog_handlers.go
@@ -12,6 +12,84 @@ import (
 
 func registerAuditLog(r chi.Router, d Deps) {
 	r.Get("/audit", auditLogList(d))
+	r.Post("/audit/{id}/rollback", auditLogRollback(d))
+}
+
+func auditLogRollback(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idStr := chi.URLParam(r, "id")
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil || id <= 0 {
+			transport.WriteBadRequestErr(w, "invalid id", err)
+			return
+		}
+
+		entry, err := d.AuditLogService.GetById(r.Context(), id)
+		if err != nil {
+			d.Logger.Error().Err(err).Int64("id", id).Msg("audit entry not found for rollback")
+			transport.WriteErr(w, err)
+			return
+		}
+
+		if entry.Action != domain.AuditActionAddDomainRule && entry.Action != domain.AuditActionRemoveDomainRule {
+			transport.WriteBadRequestErr(w, "only domain rule entries can be rolled back", nil)
+			return
+		}
+
+		if entry.TargetDomain == nil || entry.RuleType == nil || entry.RuleKind == nil {
+			d.Logger.Error().Int64("id", id).Msg("audit entry missing required fields for rollback")
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		ruleType := domain.RuleType(*entry.RuleType)
+		ruleKind := domain.RuleKind(*entry.RuleKind)
+		targetDomain := *entry.TargetDomain
+
+		var nodes []rollbackNodeResultDTO
+		if entry.Action == domain.AuditActionAddDomainRule {
+			results := d.DomainRuleService.Remove(r.Context(), domain.RemoveDomainRuleCommand{
+				Type:   ruleType,
+				Kind:   ruleKind,
+				Domain: targetDomain,
+			})
+			nodes = make([]rollbackNodeResultDTO, 0, len(results))
+			for _, nr := range results {
+				node := rollbackNodeResultDTO{
+					NodeId:   nr.PiholeNode.Id,
+					NodeName: nr.PiholeNode.Name,
+					Success:  nr.Success,
+				}
+				if nr.Error != nil {
+					node.Error = nr.Error.Error()
+				}
+				nodes = append(nodes, node)
+			}
+		} else {
+			results := d.DomainRuleService.Add(r.Context(), domain.AddDomainRulesCommand{
+				Type:    ruleType,
+				Kind:    ruleKind,
+				Domains: []string{targetDomain},
+			})
+			nodes = make([]rollbackNodeResultDTO, 0, len(results))
+			for _, nr := range results {
+				node := rollbackNodeResultDTO{
+					NodeId:   nr.PiholeNode.Id,
+					NodeName: nr.PiholeNode.Name,
+					Success:  nr.Success,
+				}
+				if nr.Error != nil {
+					node.Error = nr.Error.Error()
+				}
+				nodes = append(nodes, node)
+			}
+		}
+
+		transport.WriteJSON(w, http.StatusOK, rollbackResponseDTO{
+			OriginalId: id,
+			Nodes:      nodes,
+		})
+	}
 }
 
 func auditLogList(d Deps) http.HandlerFunc {

--- a/backend/internal/http/api/v1/interface.go
+++ b/backend/internal/http/api/v1/interface.go
@@ -11,6 +11,10 @@ import (
 	usersvc "github.com/auto-dns/pihole-cluster-admin/internal/service/user"
 )
 
+type auditLogService interface {
+	List(ctx context.Context, q domain.ListAuditEntriesQuery) ([]*domain.AuditEntry, int, error)
+}
+
 type authService interface {
 	Login(params authsvc.LoginCommand) (*domain.User, string, error)
 	Logout(sessionId string) error

--- a/backend/internal/http/api/v1/interface.go
+++ b/backend/internal/http/api/v1/interface.go
@@ -12,6 +12,7 @@ import (
 )
 
 type auditLogService interface {
+	GetById(ctx context.Context, id int64) (*domain.AuditEntry, error)
 	List(ctx context.Context, q domain.ListAuditEntriesQuery) ([]*domain.AuditEntry, int, error)
 }
 

--- a/backend/internal/http/api/v1/router.go
+++ b/backend/internal/http/api/v1/router.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Deps struct {
+	AuditLogService        auditLogService
 	AuthService            authService
 	ClusterBlockingService clusterBlockingService
 	DomainRuleService      domainRuleService
@@ -39,6 +40,7 @@ func RegisterAPIV1(r chi.Router, d Deps) {
 	r.Group(func(r chi.Router) {
 		r.Use(d.AuthMW)
 		r.Use(middleware.CSRF)
+		registerAuditLog(r, d)
 		registerAuthPrivate(r, d)
 		registerClusterBlocking(r, d)
 		registerHealth(r, d)

--- a/backend/internal/http/context/actor.go
+++ b/backend/internal/http/context/actor.go
@@ -1,0 +1,16 @@
+package context
+
+import "context"
+
+type actorKey struct{}
+
+func WithActor(ctx context.Context, username string) context.Context {
+	return context.WithValue(ctx, actorKey{}, username)
+}
+
+func Actor(ctx context.Context) string {
+	if v, ok := ctx.Value(actorKey{}).(string); ok && v != "" {
+		return v
+	}
+	return "unknown"
+}

--- a/backend/internal/http/middleware/auth.go
+++ b/backend/internal/http/middleware/auth.go
@@ -5,12 +5,18 @@ import (
 
 	"github.com/auto-dns/pihole-cluster-admin/internal/config"
 	requestctx "github.com/auto-dns/pihole-cluster-admin/internal/http/context"
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
 	"github.com/auto-dns/pihole-cluster-admin/internal/util"
 	"github.com/rs/zerolog"
 )
 
+type userGetter interface {
+	GetUser(id int64) (*domain.User, error)
+}
+
 type AuthDeps struct {
 	Sessions sessionManager
+	Users    userGetter
 	Cfg      config.SessionConfig
 	Logger   zerolog.Logger
 }
@@ -36,8 +42,13 @@ func RequireAuth(d AuthDeps) func(http.Handler) http.Handler {
 				return
 			}
 
-			// Pass username to request context
 			ctx := requestctx.WithUserID(r.Context(), userId)
+
+			if d.Users != nil {
+				if user, err := d.Users.GetUser(userId); err == nil {
+					ctx = requestctx.WithActor(ctx, user.Username)
+				}
+			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})

--- a/backend/internal/migrations/002_audit_log.down.sql
+++ b/backend/internal/migrations/002_audit_log.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS audit_log_created_at_idx;
+DROP TABLE IF EXISTS audit_log;

--- a/backend/internal/migrations/002_audit_log.up.sql
+++ b/backend/internal/migrations/002_audit_log.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    actor TEXT NOT NULL,
+    action TEXT NOT NULL CHECK (action IN ('add_domain_rule', 'remove_domain_rule', 'set_cluster_blocking', 'set_node_blocking')),
+    target_domain TEXT,
+    rule_type TEXT,
+    rule_kind TEXT,
+    blocking_enabled INTEGER,
+    blocking_timer INTEGER,
+    target_node_id INTEGER,
+    target_node_name TEXT,
+    node_results TEXT NOT NULL DEFAULT '[]',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS audit_log_created_at_idx ON audit_log(created_at);

--- a/backend/internal/service/auditlog/interface.go
+++ b/backend/internal/service/auditlog/interface.go
@@ -8,5 +8,6 @@ import (
 
 type auditStore interface {
 	Create(ctx context.Context, params domain.CreateAuditEntryParams) (*domain.AuditEntry, error)
+	GetById(ctx context.Context, id int64) (*domain.AuditEntry, error)
 	List(ctx context.Context, q domain.ListAuditEntriesQuery) ([]*domain.AuditEntry, int, error)
 }

--- a/backend/internal/service/auditlog/interface.go
+++ b/backend/internal/service/auditlog/interface.go
@@ -1,0 +1,12 @@
+package auditlogsvc
+
+import (
+	"context"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+)
+
+type auditStore interface {
+	Create(ctx context.Context, params domain.CreateAuditEntryParams) (*domain.AuditEntry, error)
+	List(ctx context.Context, q domain.ListAuditEntriesQuery) ([]*domain.AuditEntry, int, error)
+}

--- a/backend/internal/service/auditlog/service.go
+++ b/backend/internal/service/auditlog/service.go
@@ -1,0 +1,29 @@
+package auditlogsvc
+
+import (
+	"context"
+
+	requestctx "github.com/auto-dns/pihole-cluster-admin/internal/http/context"
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/rs/zerolog"
+)
+
+type Service struct {
+	store  auditStore
+	logger zerolog.Logger
+}
+
+func NewService(store auditStore, logger zerolog.Logger) *Service {
+	return &Service{store: store, logger: logger}
+}
+
+func (s *Service) Record(ctx context.Context, params domain.CreateAuditEntryParams) {
+	params.Actor = requestctx.Actor(ctx)
+	if _, err := s.store.Create(ctx, params); err != nil {
+		s.logger.Warn().Err(err).Str("action", string(params.Action)).Msg("failed to record audit entry")
+	}
+}
+
+func (s *Service) List(ctx context.Context, q domain.ListAuditEntriesQuery) ([]*domain.AuditEntry, int, error) {
+	return s.store.List(ctx, q)
+}

--- a/backend/internal/service/auditlog/service.go
+++ b/backend/internal/service/auditlog/service.go
@@ -24,6 +24,10 @@ func (s *Service) Record(ctx context.Context, params domain.CreateAuditEntryPara
 	}
 }
 
+func (s *Service) GetById(ctx context.Context, id int64) (*domain.AuditEntry, error) {
+	return s.store.GetById(ctx, id)
+}
+
 func (s *Service) List(ctx context.Context, q domain.ListAuditEntriesQuery) ([]*domain.AuditEntry, int, error) {
 	return s.store.List(ctx, q)
 }

--- a/backend/internal/service/clusterblocking/interface.go
+++ b/backend/internal/service/clusterblocking/interface.go
@@ -17,3 +17,7 @@ type broker interface {
 	SubscribersChanged() <-chan struct{}
 	Publish(topic string, payload any)
 }
+
+type auditLogger interface {
+	Record(ctx context.Context, params domain.CreateAuditEntryParams)
+}

--- a/backend/internal/service/clusterblocking/service.go
+++ b/backend/internal/service/clusterblocking/service.go
@@ -10,20 +10,23 @@ import (
 	"github.com/auto-dns/pihole-cluster-admin/internal/logger"
 	"github.com/auto-dns/pihole-cluster-admin/internal/poller"
 	"github.com/auto-dns/pihole-cluster-admin/internal/realtime"
+	"github.com/auto-dns/pihole-cluster-admin/internal/util"
 	"github.com/rs/zerolog"
 )
 
 type Service struct {
 	cluster cluster
 	broker  broker
+	audit   auditLogger
 	cfg     config.PublisherConfig
 	logger  zerolog.Logger
 }
 
-func NewService(cluster cluster, broker broker, cfg config.PublisherConfig, logger zerolog.Logger) *Service {
+func NewService(cluster cluster, broker broker, audit auditLogger, cfg config.PublisherConfig, logger zerolog.Logger) *Service {
 	return &Service{
 		cluster: cluster,
 		broker:  broker,
+		audit:   audit,
 		cfg:     cfg,
 		logger:  logger,
 	}
@@ -38,14 +41,48 @@ func (s *Service) SetState(ctx context.Context, blocking bool, timer *int) (*dom
 	nodes := s.cluster.SetBlockingState(ctx, blocking, timer)
 	state := processClusterResponse(nodes)
 	s.broker.Publish(realtime.TopicClusterBlockingV1, state)
+
+	nodeResults := make([]domain.AuditNodeResult, 0, len(nodes))
+	for _, nr := range nodes {
+		nodeResults = append(nodeResults, domain.AuditNodeResult{
+			NodeId:   nr.PiholeNode.Id,
+			NodeName: nr.PiholeNode.Name,
+			Success:  nr.Success,
+			Error:    util.ErrorString(nr.Error),
+		})
+	}
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:          domain.AuditActionSetClusterBlocking,
+		BlockingEnabled: &blocking,
+		BlockingTimer:   timer,
+		NodeResults:     nodeResults,
+	})
+
 	return state, nil
 }
 
 func (s *Service) SetStateForNode(ctx context.Context, nodeID int64, blocking bool, timer *int) (*domain.ClusterBlockingState, error) {
-	_, err := s.cluster.SetBlockingStateForNode(ctx, nodeID, blocking, timer)
+	nr, err := s.cluster.SetBlockingStateForNode(ctx, nodeID, blocking, timer)
 	if err != nil {
 		return nil, err
 	}
+
+	nodeResults := []domain.AuditNodeResult{{
+		NodeId:   nr.PiholeNode.Id,
+		NodeName: nr.PiholeNode.Name,
+		Success:  nr.Success,
+		Error:    util.ErrorString(nr.Error),
+	}}
+	nodeName := nr.PiholeNode.Name
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:          domain.AuditActionSetNodeBlocking,
+		BlockingEnabled: &blocking,
+		BlockingTimer:   timer,
+		TargetNodeId:    &nodeID,
+		TargetNodeName:  &nodeName,
+		NodeResults:     nodeResults,
+	})
+
 	nodes := s.cluster.GetBlockingState(ctx)
 	state := processClusterResponse(nodes)
 	s.broker.Publish(realtime.TopicClusterBlockingV1, state)

--- a/backend/internal/service/domainrule/interface.go
+++ b/backend/internal/service/domainrule/interface.go
@@ -11,3 +11,7 @@ type cluster interface {
 	AddDomainRule(ctx context.Context, cmd domain.AddDomainRulesCommand) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult]
 	RemoveDomainRule(ctx context.Context, cmd domain.RemoveDomainRuleCommand) map[int64]*domain.NodeResult[struct{}]
 }
+
+type auditLogger interface {
+	Record(ctx context.Context, params domain.CreateAuditEntryParams)
+}

--- a/backend/internal/service/domainrule/service.go
+++ b/backend/internal/service/domainrule/service.go
@@ -2,18 +2,19 @@ package domainrulesvc
 
 import (
 	"context"
+	"strings"
 
 	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/util"
 )
 
 type Service struct {
 	cluster cluster
+	audit   auditLogger
 }
 
-func NewService(cluster cluster) *Service {
-	return &Service{
-		cluster: cluster,
-	}
+func NewService(cluster cluster, audit auditLogger) *Service {
+	return &Service{cluster: cluster, audit: audit}
 }
 
 func (s *Service) List(ctx context.Context, q domain.ListDomainRulesQuery) map[int64]*domain.NodeResult[*domain.DomainRuleSet] {
@@ -21,9 +22,60 @@ func (s *Service) List(ctx context.Context, q domain.ListDomainRulesQuery) map[i
 }
 
 func (s *Service) Add(ctx context.Context, cmd domain.AddDomainRulesCommand) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult] {
-	return s.cluster.AddDomainRule(ctx, cmd)
+	results := s.cluster.AddDomainRule(ctx, cmd)
+
+	targetDomain := strings.Join(cmd.Domains, ", ")
+	ruleType := string(cmd.Type)
+	ruleKind := string(cmd.Kind)
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:       domain.AuditActionAddDomainRule,
+		TargetDomain: &targetDomain,
+		RuleType:     &ruleType,
+		RuleKind:     &ruleKind,
+		NodeResults:  nodeResultsFromAdd(results),
+	})
+
+	return results
 }
 
 func (s *Service) Remove(ctx context.Context, cmd domain.RemoveDomainRuleCommand) map[int64]*domain.NodeResult[struct{}] {
-	return s.cluster.RemoveDomainRule(ctx, cmd)
+	results := s.cluster.RemoveDomainRule(ctx, cmd)
+
+	ruleType := string(cmd.Type)
+	ruleKind := string(cmd.Kind)
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:       domain.AuditActionRemoveDomainRule,
+		TargetDomain: &cmd.Domain,
+		RuleType:     &ruleType,
+		RuleKind:     &ruleKind,
+		NodeResults:  nodeResultsFromRemove(results),
+	})
+
+	return results
+}
+
+func nodeResultsFromAdd(results map[int64]*domain.NodeResult[*domain.AddDomainRulesResult]) []domain.AuditNodeResult {
+	out := make([]domain.AuditNodeResult, 0, len(results))
+	for _, nr := range results {
+		out = append(out, domain.AuditNodeResult{
+			NodeId:   nr.PiholeNode.Id,
+			NodeName: nr.PiholeNode.Name,
+			Success:  nr.Success,
+			Error:    util.ErrorString(nr.Error),
+		})
+	}
+	return out
+}
+
+func nodeResultsFromRemove(results map[int64]*domain.NodeResult[struct{}]) []domain.AuditNodeResult {
+	out := make([]domain.AuditNodeResult, 0, len(results))
+	for _, nr := range results {
+		out = append(out, domain.AuditNodeResult{
+			NodeId:   nr.PiholeNode.Id,
+			NodeName: nr.PiholeNode.Name,
+			Success:  nr.Success,
+			Error:    util.ErrorString(nr.Error),
+		})
+	}
+	return out
 }

--- a/backend/internal/store/auditlog.go
+++ b/backend/internal/store/auditlog.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"strings"
 
 	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/errs"
 	"github.com/rs/zerolog"
 )
 
@@ -96,6 +98,14 @@ func (s *AuditLogStore) List(ctx context.Context, q domain.ListAuditEntriesQuery
 		entries = append(entries, rowToAuditEntry(r))
 	}
 	return entries, total, rows.Err()
+}
+
+func (s *AuditLogStore) GetById(ctx context.Context, id int64) (*domain.AuditEntry, error) {
+	entry, err := s.getRow(ctx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, errs.NotFound("audit entry not found", err)
+	}
+	return entry, err
 }
 
 func (s *AuditLogStore) getRow(ctx context.Context, id int64) (*domain.AuditEntry, error) {

--- a/backend/internal/store/auditlog.go
+++ b/backend/internal/store/auditlog.go
@@ -1,0 +1,141 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/rs/zerolog"
+)
+
+type AuditLogStore struct {
+	db     *sql.DB
+	logger zerolog.Logger
+}
+
+func NewAuditLogStore(db *sql.DB, logger zerolog.Logger) *AuditLogStore {
+	return &AuditLogStore{db: db, logger: logger}
+}
+
+func (s *AuditLogStore) Create(ctx context.Context, params domain.CreateAuditEntryParams) (*domain.AuditEntry, error) {
+	resultsJSON, err := json.Marshal(params.NodeResults)
+	if err != nil {
+		return nil, err
+	}
+
+	var blockingEnabled *int64
+	if params.BlockingEnabled != nil {
+		v := int64(0)
+		if *params.BlockingEnabled {
+			v = 1
+		}
+		blockingEnabled = &v
+	}
+
+	res, err := s.db.ExecContext(ctx, `
+		INSERT INTO audit_log
+			(actor, action, target_domain, rule_type, rule_kind, blocking_enabled, blocking_timer,
+			 target_node_id, target_node_name, node_results)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		params.Actor, string(params.Action),
+		params.TargetDomain, params.RuleType, params.RuleKind,
+		blockingEnabled, params.BlockingTimer,
+		params.TargetNodeId, params.TargetNodeName,
+		string(resultsJSON),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+
+	return s.getRow(ctx, id)
+}
+
+func (s *AuditLogStore) List(ctx context.Context, q domain.ListAuditEntriesQuery) ([]*domain.AuditEntry, int, error) {
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	offset := q.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	var total int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM audit_log`).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, actor, action, target_domain, rule_type, rule_kind, blocking_enabled, blocking_timer,
+		       target_node_id, target_node_name, node_results, created_at
+		FROM audit_log
+		ORDER BY created_at DESC
+		LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var entries []*domain.AuditEntry
+	for rows.Next() {
+		var r auditLogRow
+		if err := rows.Scan(
+			&r.Id, &r.Actor, &r.Action, &r.TargetDomain, &r.RuleType, &r.RuleKind,
+			&r.BlockingEnabled, &r.BlockingTimer, &r.TargetNodeId, &r.TargetNodeName,
+			&r.NodeResults, &r.CreatedAt,
+		); err != nil {
+			return nil, 0, err
+		}
+		entries = append(entries, rowToAuditEntry(r))
+	}
+	return entries, total, rows.Err()
+}
+
+func (s *AuditLogStore) getRow(ctx context.Context, id int64) (*domain.AuditEntry, error) {
+	var r auditLogRow
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, actor, action, target_domain, rule_type, rule_kind, blocking_enabled, blocking_timer,
+		       target_node_id, target_node_name, node_results, created_at
+		FROM audit_log WHERE id = ?`, id).Scan(
+		&r.Id, &r.Actor, &r.Action, &r.TargetDomain, &r.RuleType, &r.RuleKind,
+		&r.BlockingEnabled, &r.BlockingTimer, &r.TargetNodeId, &r.TargetNodeName,
+		&r.NodeResults, &r.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return rowToAuditEntry(r), nil
+}
+
+func rowToAuditEntry(r auditLogRow) *domain.AuditEntry {
+	entry := &domain.AuditEntry{
+		Id:             r.Id,
+		Actor:          r.Actor,
+		Action:         domain.AuditAction(r.Action),
+		TargetDomain:   r.TargetDomain,
+		RuleType:       r.RuleType,
+		RuleKind:       r.RuleKind,
+		BlockingTimer:  r.BlockingTimer,
+		TargetNodeId:   r.TargetNodeId,
+		TargetNodeName: r.TargetNodeName,
+		CreatedAt:      r.CreatedAt,
+	}
+	if r.BlockingEnabled != nil {
+		v := *r.BlockingEnabled != 0
+		entry.BlockingEnabled = &v
+	}
+	if r.NodeResults != "" && r.NodeResults != "null" {
+		_ = json.NewDecoder(strings.NewReader(r.NodeResults)).Decode(&entry.NodeResults)
+	}
+	if entry.NodeResults == nil {
+		entry.NodeResults = []domain.AuditNodeResult{}
+	}
+	return entry
+}

--- a/backend/internal/store/auditlogwire.go
+++ b/backend/internal/store/auditlogwire.go
@@ -1,0 +1,18 @@
+package store
+
+import "time"
+
+type auditLogRow struct {
+	Id              int64
+	Actor           string
+	Action          string
+	TargetDomain    *string
+	RuleType        *string
+	RuleKind        *string
+	BlockingEnabled *int64
+	BlockingTimer   *int
+	TargetNodeId    *int64
+	TargetNodeName  *string
+	NodeResults     string
+	CreatedAt       time.Time
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -15,6 +15,7 @@ import { SetupPiholes } from '@/pages/Setup/SetupPiholes';
 import { Login } from '@/pages/Login';
 import { UnhandledRoute } from './routes/UnhandledRoute';
 import { Account } from '@/pages/Account/Account';
+import { Audit } from '@/pages/Audit';
 
 export const router = createBrowserRouter([
 	{
@@ -47,6 +48,11 @@ export const router = createBrowserRouter([
 						path: '/recent-blocks',
 						Component: RecentBlocks,
 						handle: { layoutOptions: { pageTitle: 'Recent Blocks' } },
+					},
+					{
+						path: '/audit',
+						Component: Audit,
+						handle: { layoutOptions: { pageTitle: 'Audit Log' } },
 					},
 					{
 						path: '/account',

--- a/frontend/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@ import { NavLink } from 'react-router';
 import {
 	ChevronRight,
 	ChevronLeft,
+	Clock,
 	FileText,
 	Home,
 	List,
@@ -25,6 +26,7 @@ const links = [
 	{ to: '/recent-blocks', label: 'Recent Blocks', icon: ShieldAlert },
 	{ to: '/query', label: 'Query Log', icon: FileText },
 	{ to: '/domains', label: 'Domains', icon: List },
+	{ to: '/audit', label: 'Audit Log', icon: Clock },
 	{ to: '/settings', label: 'Settings', icon: SettingsIcon },
 ];
 

--- a/frontend/src/lib/api/audit.ts
+++ b/frontend/src/lib/api/audit.ts
@@ -1,6 +1,10 @@
 import { apiV1Fetch } from './client';
-import type { AuditListResponse } from '@/types/audit';
+import type { AuditListResponse, RollbackResponse } from '@/types/audit';
 
 export async function listAuditEntries(limit = 50, offset = 0): Promise<AuditListResponse> {
 	return apiV1Fetch<AuditListResponse>(`/audit?limit=${limit}&offset=${offset}`);
+}
+
+export async function rollbackAuditEntry(id: number): Promise<RollbackResponse> {
+	return apiV1Fetch<RollbackResponse>(`/audit/${id}/rollback`, { method: 'POST' });
 }

--- a/frontend/src/lib/api/audit.ts
+++ b/frontend/src/lib/api/audit.ts
@@ -1,0 +1,6 @@
+import { apiV1Fetch } from './client';
+import type { AuditListResponse } from '@/types/audit';
+
+export async function listAuditEntries(limit = 50, offset = 0): Promise<AuditListResponse> {
+	return apiV1Fetch<AuditListResponse>(`/audit?limit=${limit}&offset=${offset}`);
+}

--- a/frontend/src/pages/Audit.module.scss
+++ b/frontend/src/pages/Audit.module.scss
@@ -1,0 +1,297 @@
+@use '@/styles/mixins' as *;
+@use '@/styles/variables' as *;
+
+.page {
+	padding: 1.25rem;
+	max-width: 72rem;
+	margin-inline: auto;
+}
+
+// ---- Toolbar ----
+
+.toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+	margin-bottom: 1rem;
+}
+
+.totalCount {
+	font-size: 0.8rem;
+	color: var(--text-secondary);
+}
+
+.refreshBtn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.2rem;
+	height: 2.2rem;
+	padding: 0 !important;
+	background: var(--btn-surface-bg) !important;
+	color: var(--btn-surface-text) !important;
+	border: 1px solid var(--border-card);
+	border-radius: var(--input-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: var(--btn-surface-bg-hover) !important;
+	}
+
+	&:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+}
+
+// ---- Table ----
+
+.tableWrap {
+	overflow-x: auto;
+	background: var(--bg-card);
+	border: 1px solid var(--border-card);
+	border-radius: var(--card-radius);
+	box-shadow: var(--card-shadow);
+}
+
+.table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.875rem;
+
+	thead tr {
+		background: var(--bg-header);
+	}
+
+	th {
+		padding: 0.6rem 0.75rem;
+		text-align: left;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-secondary);
+		white-space: nowrap;
+		border-bottom: 1px solid var(--border-card);
+	}
+
+	tbody tr {
+		border-bottom: 1px solid var(--border-card);
+
+		&:last-child {
+			border-bottom: none;
+		}
+
+		&:nth-child(even):not(.expandedRow) {
+			background: var(--bg-table-stripe);
+		}
+	}
+
+	td {
+		padding: 0.55rem 0.75rem;
+		vertical-align: middle;
+		color: var(--text-primary);
+	}
+}
+
+.row {
+	&[data-expandable] {
+		cursor: pointer;
+
+		&:hover {
+			background: var(--bg-header) !important;
+		}
+	}
+}
+
+.chevronCell {
+	width: 1.5rem;
+	padding: 0 0.25rem 0 0.5rem !important;
+	color: var(--text-secondary);
+}
+
+.chevron {
+	display: block;
+}
+
+.timeCell {
+	white-space: nowrap;
+	font-size: 0.8rem;
+	color: var(--text-secondary);
+	font-family: monospace;
+}
+
+.actorCell {
+	font-size: 0.8rem;
+	color: var(--text-secondary);
+}
+
+.descCell {
+	font-family: monospace;
+	font-size: 0.82rem;
+	max-width: 22rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.statusCell {
+	display: flex;
+	align-items: center;
+	gap: 0.3rem;
+}
+
+.statusText {
+	font-size: 0.8rem;
+	color: var(--accent-warn);
+}
+
+// ---- Action badge ----
+
+.actionBadge {
+	display: inline-block;
+	font-size: 0.72rem;
+	font-weight: 600;
+	padding: 0.12rem 0.45rem;
+	border-radius: var(--border-radius);
+	white-space: nowrap;
+	background: var(--bg-muted);
+	color: var(--text-secondary);
+
+	&[data-action='add_domain_rule'] {
+		background: color-mix(in oklab, var(--accent-success) 12%, transparent);
+		color: var(--accent-success);
+	}
+
+	&[data-action='remove_domain_rule'] {
+		background: color-mix(in oklab, var(--accent-danger) 12%, transparent);
+		color: var(--accent-danger);
+	}
+
+	&[data-action='set_cluster_blocking'],
+	&[data-action='set_node_blocking'] {
+		background: color-mix(in oklab, var(--accent-primary) 12%, transparent);
+		color: var(--accent-primary);
+	}
+}
+
+// ---- Status icons ----
+
+.iconOk {
+	color: var(--accent-success);
+	flex-shrink: 0;
+}
+
+.iconFail {
+	color: var(--accent-danger);
+	flex-shrink: 0;
+}
+
+// ---- Expanded row ----
+
+.expandedRow td {
+	padding: 0 !important;
+	background: var(--bg-page);
+}
+
+.nodeResults {
+	padding: 0.5rem 1rem 0.5rem 2.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+}
+
+.nodeResult {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.82rem;
+}
+
+.nodeName {
+	font-weight: 500;
+}
+
+.nodeError {
+	color: var(--accent-danger);
+	font-family: monospace;
+	font-size: 0.78rem;
+}
+
+// ---- Pagination ----
+
+.pagination {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 1rem;
+	margin-top: 1rem;
+}
+
+.pageBtn {
+	padding: 0.35rem 0.9rem;
+	font-size: 0.875rem;
+	background: var(--btn-surface-bg);
+	color: var(--btn-surface-text);
+	border: 1px solid var(--border-card);
+	border-radius: var(--input-radius);
+	cursor: pointer;
+
+	&:hover:not(:disabled) {
+		background: var(--btn-surface-bg-hover);
+	}
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+}
+
+.pageInfo {
+	font-size: 0.875rem;
+	color: var(--text-secondary);
+}
+
+// ---- Feedback ----
+
+.error {
+	padding: 0.75rem 1rem;
+	background: color-mix(in oklab, var(--accent-danger) 10%, transparent);
+	color: var(--accent-danger);
+	border-radius: var(--input-radius);
+	margin-bottom: 1rem;
+	font-size: 0.9rem;
+}
+
+.loadingState,
+.emptyState {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 3rem 1rem;
+	justify-content: center;
+	color: var(--text-secondary);
+	font-size: 0.9rem;
+}
+
+.spin {
+	animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+	from { transform: rotate(0deg); }
+	to { transform: rotate(360deg); }
+}
+
+@include respond-max($breakpoint-md) {
+	.page {
+		padding: 1rem;
+	}
+
+	.table thead th:nth-child(4),
+	.table tbody td:nth-child(4) {
+		display: none;
+	}
+}

--- a/frontend/src/pages/Audit.module.scss
+++ b/frontend/src/pages/Audit.module.scss
@@ -189,6 +189,99 @@
 	flex-shrink: 0;
 }
 
+// ---- Undo column ----
+
+.undoCell {
+	width: 2.5rem;
+	text-align: center;
+	padding: 0 0.25rem !important;
+}
+
+.undoBtn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.75rem;
+	height: 1.75rem;
+	padding: 0;
+	background: transparent;
+	color: var(--text-secondary);
+	border: 1px solid transparent;
+	border-radius: var(--input-radius);
+	cursor: pointer;
+	opacity: 0;
+	transition: opacity var(--transition-fast), background var(--transition-fast);
+
+	tr:hover & {
+		opacity: 1;
+	}
+
+	&:hover {
+		background: var(--btn-surface-bg);
+		border-color: var(--border-card);
+		color: var(--text-primary);
+	}
+}
+
+.undoConfirm {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	font-size: 0.78rem;
+	white-space: nowrap;
+	color: var(--text-primary);
+}
+
+.undoYes {
+	font-size: 0.78rem;
+	padding: 0.1rem 0.35rem;
+	background: color-mix(in oklab, var(--accent-danger) 12%, transparent);
+	color: var(--accent-danger);
+	border: 1px solid color-mix(in oklab, var(--accent-danger) 30%, transparent);
+	border-radius: var(--input-radius);
+	cursor: pointer;
+
+	&:hover {
+		background: color-mix(in oklab, var(--accent-danger) 22%, transparent);
+	}
+}
+
+.undoNo {
+	font-size: 0.78rem;
+	padding: 0.1rem 0.35rem;
+	background: var(--btn-surface-bg);
+	color: var(--btn-surface-text);
+	border: 1px solid var(--border-card);
+	border-radius: var(--input-radius);
+	cursor: pointer;
+
+	&:hover {
+		background: var(--btn-surface-bg-hover);
+	}
+}
+
+// ---- Rollback results ----
+
+.rollbackResults {
+	padding: 0.5rem 1rem 0.5rem 2.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+}
+
+.rollbackLabel {
+	font-size: 0.78rem;
+	color: var(--text-secondary);
+	font-weight: 600;
+	margin-bottom: 0.1rem;
+}
+
+.rollbackError {
+	padding: 0.4rem 1rem 0.4rem 2.5rem;
+	font-size: 0.82rem;
+	color: var(--accent-danger);
+}
+
 // ---- Expanded row ----
 
 .expandedRow td {

--- a/frontend/src/pages/Audit.tsx
+++ b/frontend/src/pages/Audit.tsx
@@ -1,0 +1,229 @@
+import { useState, useEffect, useCallback } from 'react';
+import { RefreshCw, CheckCircle, XCircle, ChevronDown, ChevronRight } from 'lucide-react';
+import { listAuditEntries } from '@/lib/api/audit';
+import type { AuditEntry, AuditAction } from '@/types/audit';
+import styles from './Audit.module.scss';
+
+const ACTION_LABELS: Record<AuditAction, string> = {
+	add_domain_rule: 'Added domain rule',
+	remove_domain_rule: 'Removed domain rule',
+	set_cluster_blocking: 'Set cluster blocking',
+	set_node_blocking: 'Set node blocking',
+};
+
+function actionLabel(action: AuditAction) {
+	return ACTION_LABELS[action] ?? action;
+}
+
+function entryDescription(entry: AuditEntry): string {
+	switch (entry.action) {
+		case 'add_domain_rule':
+		case 'remove_domain_rule': {
+			const typeLabel = entry.ruleType === 'allow' ? 'allowlist' : 'blocklist';
+			const kindLabel = entry.ruleKind === 'regex' ? ' (regex)' : '';
+			return `${entry.targetDomain ?? '—'} → ${typeLabel}${kindLabel}`;
+		}
+		case 'set_cluster_blocking':
+			return entry.blockingEnabled
+				? `Enabled${entry.blockingTimer ? ` (${entry.blockingTimer}s timer)` : ''}`
+				: 'Disabled';
+		case 'set_node_blocking':
+			return `${entry.targetNodeName ?? `node ${entry.targetNodeId}`}: ${
+				entry.blockingEnabled
+					? `enabled${entry.blockingTimer ? ` (${entry.blockingTimer}s)` : ''}`
+					: 'disabled'
+			}`;
+		default:
+			return '—';
+	}
+}
+
+function formatTime(iso: string): string {
+	const d = new Date(iso);
+	return d.toLocaleString(undefined, {
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+	});
+}
+
+const PAGE_SIZE = 50;
+
+function AuditRow({ entry }: { entry: AuditEntry }) {
+	const [expanded, setExpanded] = useState(false);
+	const hasResults = entry.nodeResults.length > 0;
+	const allSuccess = entry.nodeResults.every((r) => r.success);
+	const anyFailure = entry.nodeResults.some((r) => !r.success);
+
+	return (
+		<>
+			<tr
+				className={styles.row}
+				data-expandable={hasResults || undefined}
+				onClick={() => hasResults && setExpanded((v) => !v)}
+			>
+				<td className={styles.chevronCell}>
+					{hasResults ? (
+						expanded ? (
+							<ChevronDown size={14} className={styles.chevron} />
+						) : (
+							<ChevronRight size={14} className={styles.chevron} />
+						)
+					) : null}
+				</td>
+				<td className={styles.timeCell}>{formatTime(entry.createdAt)}</td>
+				<td>
+					<span className={styles.actionBadge} data-action={entry.action}>
+						{actionLabel(entry.action)}
+					</span>
+				</td>
+				<td className={styles.descCell}>{entryDescription(entry)}</td>
+				<td className={styles.actorCell}>{entry.actor}</td>
+				<td className={styles.statusCell}>
+					{anyFailure ? (
+						<XCircle size={15} className={styles.iconFail} />
+					) : (
+						<CheckCircle size={15} className={styles.iconOk} />
+					)}
+					{!allSuccess && anyFailure && (
+						<span className={styles.statusText}>
+							{entry.nodeResults.filter((r) => r.success).length}/
+							{entry.nodeResults.length}
+						</span>
+					)}
+				</td>
+			</tr>
+			{expanded && hasResults && (
+				<tr className={styles.expandedRow}>
+					<td colSpan={6}>
+						<div className={styles.nodeResults}>
+							{entry.nodeResults.map((nr) => (
+								<div key={nr.nodeId} className={styles.nodeResult}>
+									{nr.success ? (
+										<CheckCircle size={13} className={styles.iconOk} />
+									) : (
+										<XCircle size={13} className={styles.iconFail} />
+									)}
+									<span className={styles.nodeName}>{nr.nodeName}</span>
+									{nr.error && (
+										<span className={styles.nodeError}>{nr.error}</span>
+									)}
+								</div>
+							))}
+						</div>
+					</td>
+				</tr>
+			)}
+		</>
+	);
+}
+
+export function Audit() {
+	const [entries, setEntries] = useState<AuditEntry[]>([]);
+	const [total, setTotal] = useState(0);
+	const [offset, setOffset] = useState(0);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const fetchPage = useCallback(async (pageOffset: number) => {
+		setLoading(true);
+		setError(null);
+		try {
+			const resp = await listAuditEntries(PAGE_SIZE, pageOffset);
+			setEntries(resp.entries ?? []);
+			setTotal(resp.total);
+			setOffset(pageOffset);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to load audit log');
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		fetchPage(0);
+	}, [fetchPage]);
+
+	const totalPages = Math.ceil(total / PAGE_SIZE);
+	const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+
+	return (
+		<div className={styles.page}>
+			<div className={styles.toolbar}>
+				<span className={styles.totalCount}>
+					{total} {total === 1 ? 'entry' : 'entries'}
+				</span>
+				<button
+					type='button'
+					className={styles.refreshBtn}
+					onClick={() => fetchPage(offset)}
+					disabled={loading}
+					aria-label='Refresh'
+				>
+					<RefreshCw size={16} className={loading ? styles.spin : undefined} />
+				</button>
+			</div>
+
+			{error && <div className={styles.error}>{error}</div>}
+
+			{loading && entries.length === 0 && (
+				<div className={styles.loadingState}>
+					<RefreshCw size={20} className={styles.spin} />
+					Loading…
+				</div>
+			)}
+
+			{!loading && !error && entries.length === 0 && (
+				<div className={styles.emptyState}>No audit log entries yet.</div>
+			)}
+
+			{entries.length > 0 && (
+				<div className={styles.tableWrap}>
+					<table className={styles.table}>
+						<thead>
+							<tr>
+								<th aria-label='Expand' />
+								<th>Time</th>
+								<th>Action</th>
+								<th>Detail</th>
+								<th>Actor</th>
+								<th>Result</th>
+							</tr>
+						</thead>
+						<tbody>
+							{entries.map((e) => (
+								<AuditRow key={e.id} entry={e} />
+							))}
+						</tbody>
+					</table>
+				</div>
+			)}
+
+			{totalPages > 1 && (
+				<div className={styles.pagination}>
+					<button
+						type='button'
+						className={styles.pageBtn}
+						disabled={offset === 0 || loading}
+						onClick={() => fetchPage(Math.max(0, offset - PAGE_SIZE))}
+					>
+						Previous
+					</button>
+					<span className={styles.pageInfo}>
+						{currentPage} / {totalPages}
+					</span>
+					<button
+						type='button'
+						className={styles.pageBtn}
+						disabled={offset + PAGE_SIZE >= total || loading}
+						onClick={() => fetchPage(offset + PAGE_SIZE)}
+					>
+						Next
+					</button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/pages/Audit.tsx
+++ b/frontend/src/pages/Audit.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import { RefreshCw, CheckCircle, XCircle, ChevronDown, ChevronRight } from 'lucide-react';
-import { listAuditEntries } from '@/lib/api/audit';
-import type { AuditEntry, AuditAction } from '@/types/audit';
+import { RefreshCw, CheckCircle, XCircle, ChevronDown, ChevronRight, RotateCcw } from 'lucide-react';
+import { listAuditEntries, rollbackAuditEntry } from '@/lib/api/audit';
+import type { AuditEntry, AuditAction, RollbackNodeResult } from '@/types/audit';
 import styles from './Audit.module.scss';
 
 const ACTION_LABELS: Record<AuditAction, string> = {
@@ -51,18 +51,53 @@ function formatTime(iso: string): string {
 
 const PAGE_SIZE = 50;
 
+const ROLLBACK_ACTIONS = new Set<AuditAction>(['add_domain_rule', 'remove_domain_rule']);
+
+type RollbackState =
+	| { status: 'idle' }
+	| { status: 'confirming' }
+	| { status: 'loading' }
+	| { status: 'done'; nodes: RollbackNodeResult[] }
+	| { status: 'error'; message: string };
+
 function AuditRow({ entry }: { entry: AuditEntry }) {
 	const [expanded, setExpanded] = useState(false);
+	const [rollback, setRollback] = useState<RollbackState>({ status: 'idle' });
+
 	const hasResults = entry.nodeResults.length > 0;
 	const allSuccess = entry.nodeResults.every((r) => r.success);
 	const anyFailure = entry.nodeResults.some((r) => !r.success);
+	const canRollback = ROLLBACK_ACTIONS.has(entry.action);
+
+	async function handleRollback() {
+		if (rollback.status === 'confirming') {
+			setRollback({ status: 'loading' });
+			try {
+				const result = await rollbackAuditEntry(entry.id);
+				setRollback({ status: 'done', nodes: result.nodes });
+			} catch (err) {
+				setRollback({
+					status: 'error',
+					message: err instanceof Error ? err.message : 'Rollback failed',
+				});
+			}
+		} else {
+			setRollback({ status: 'confirming' });
+		}
+	}
+
+	function cancelRollback() {
+		setRollback({ status: 'idle' });
+	}
+
+	const colSpan = 7;
 
 	return (
 		<>
 			<tr
 				className={styles.row}
 				data-expandable={hasResults || undefined}
-				onClick={() => hasResults && setExpanded((v) => !v)}
+				onClick={() => hasResults && rollback.status === 'idle' && setExpanded((v) => !v)}
 			>
 				<td className={styles.chevronCell}>
 					{hasResults ? (
@@ -94,28 +129,77 @@ function AuditRow({ entry }: { entry: AuditEntry }) {
 						</span>
 					)}
 				</td>
+				<td className={styles.undoCell} onClick={(e) => e.stopPropagation()}>
+					{canRollback && rollback.status === 'idle' && (
+						<button
+							type='button'
+							className={styles.undoBtn}
+							onClick={handleRollback}
+							title='Undo this action'
+						>
+							<RotateCcw size={13} />
+						</button>
+					)}
+					{canRollback && rollback.status === 'confirming' && (
+						<span className={styles.undoConfirm}>
+							Undo?{' '}
+							<button type='button' className={styles.undoYes} onClick={handleRollback}>
+								Yes
+							</button>{' '}
+							<button type='button' className={styles.undoNo} onClick={cancelRollback}>
+								No
+							</button>
+						</span>
+					)}
+					{rollback.status === 'loading' && (
+						<RefreshCw size={13} className={styles.spin} />
+					)}
+				</td>
 			</tr>
-			{expanded && hasResults && (
+			{(expanded && hasResults) || rollback.status === 'done' || rollback.status === 'error' ? (
 				<tr className={styles.expandedRow}>
-					<td colSpan={6}>
-						<div className={styles.nodeResults}>
-							{entry.nodeResults.map((nr) => (
-								<div key={nr.nodeId} className={styles.nodeResult}>
-									{nr.success ? (
-										<CheckCircle size={13} className={styles.iconOk} />
-									) : (
-										<XCircle size={13} className={styles.iconFail} />
-									)}
-									<span className={styles.nodeName}>{nr.nodeName}</span>
-									{nr.error && (
-										<span className={styles.nodeError}>{nr.error}</span>
-									)}
-								</div>
-							))}
-						</div>
+					<td colSpan={colSpan}>
+						{rollback.status === 'done' && (
+							<div className={styles.rollbackResults}>
+								<span className={styles.rollbackLabel}>Undo result:</span>
+								{rollback.nodes.map((nr) => (
+									<div key={nr.nodeId} className={styles.nodeResult}>
+										{nr.success ? (
+											<CheckCircle size={13} className={styles.iconOk} />
+										) : (
+											<XCircle size={13} className={styles.iconFail} />
+										)}
+										<span className={styles.nodeName}>{nr.nodeName}</span>
+										{nr.error && (
+											<span className={styles.nodeError}>{nr.error}</span>
+										)}
+									</div>
+								))}
+							</div>
+						)}
+						{rollback.status === 'error' && (
+							<div className={styles.rollbackError}>{rollback.message}</div>
+						)}
+						{rollback.status !== 'done' && rollback.status !== 'error' && expanded && hasResults && (
+							<div className={styles.nodeResults}>
+								{entry.nodeResults.map((nr) => (
+									<div key={nr.nodeId} className={styles.nodeResult}>
+										{nr.success ? (
+											<CheckCircle size={13} className={styles.iconOk} />
+										) : (
+											<XCircle size={13} className={styles.iconFail} />
+										)}
+										<span className={styles.nodeName}>{nr.nodeName}</span>
+										{nr.error && (
+											<span className={styles.nodeError}>{nr.error}</span>
+										)}
+									</div>
+								))}
+							</div>
+						)}
 					</td>
 				</tr>
-			)}
+			) : null}
 		</>
 	);
 }
@@ -190,6 +274,7 @@ export function Audit() {
 								<th>Detail</th>
 								<th>Actor</th>
 								<th>Result</th>
+								<th aria-label='Undo' />
 							</tr>
 						</thead>
 						<tbody>

--- a/frontend/src/types/audit.ts
+++ b/frontend/src/types/audit.ts
@@ -32,3 +32,15 @@ export type AuditListResponse = {
 	limit: number;
 	offset: number;
 };
+
+export type RollbackNodeResult = {
+	nodeId: number;
+	nodeName: string;
+	success: boolean;
+	error?: string;
+};
+
+export type RollbackResponse = {
+	originalId: number;
+	nodes: RollbackNodeResult[];
+};

--- a/frontend/src/types/audit.ts
+++ b/frontend/src/types/audit.ts
@@ -1,0 +1,34 @@
+export type AuditAction =
+	| 'add_domain_rule'
+	| 'remove_domain_rule'
+	| 'set_cluster_blocking'
+	| 'set_node_blocking';
+
+export type AuditNodeResult = {
+	nodeId: number;
+	nodeName: string;
+	success: boolean;
+	error?: string;
+};
+
+export type AuditEntry = {
+	id: number;
+	actor: string;
+	action: AuditAction;
+	targetDomain?: string;
+	ruleType?: string;
+	ruleKind?: string;
+	blockingEnabled?: boolean;
+	blockingTimer?: number;
+	targetNodeId?: number;
+	targetNodeName?: string;
+	nodeResults: AuditNodeResult[];
+	createdAt: string;
+};
+
+export type AuditListResponse = {
+	entries: AuditEntry[];
+	total: number;
+	limit: number;
+	offset: number;
+};


### PR DESCRIPTION
## Summary

- `POST /api/v1/audit/{id}/rollback` inverts a domain rule action: added rules get removed, removed rules get re-added
- The inverse operation is handled by the existing `DomainRuleService`, so rollbacks are automatically recorded as new audit entries
- `AuditLogStore.GetById` added (wraps existing `getRow`; maps `sql.ErrNoRows` to `errs.KindNotFound` for automatic 404 response)
- Undo button on the audit page appears on hover for `add_domain_rule` / `remove_domain_rule` rows; blocking actions have no undo (already trivially reversible from the Blocking page)
- Two-step confirm (click → "Undo? Yes / No") before the request fires
- Per-node success/failure shown inline in an expanded section below the row; error shown inline on failure

Depends on #20 (audit log) being merged first.

## Test plan

- [ ] Add a domain rule → go to Audit page → hover over the entry → click Undo → confirm → verify domain is removed and a new "Removed domain rule" entry appears in the audit log
- [ ] Remove a domain rule → Undo → verify domain is re-added and a new "Added domain rule" entry appears
- [ ] Verify clicking No on the confirm cancels cleanly (button resets to Undo icon)
- [ ] Verify partial node failure case: per-node results shown with XCircle for failed nodes
- [ ] Verify rollback of a `set_cluster_blocking` or `set_node_blocking` entry returns 400
- [ ] Verify rollback of a non-existent audit entry ID returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)