### PR TITLE
feat: force-sync domain rules from a chosen source node

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -27,6 +27,7 @@ import (
 	piholesvc "github.com/auto-dns/pihole-cluster-admin/internal/service/pihole"
 	querylogsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/querylog"
 	setupsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/setup"
+	syncsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/sync"
 	usersvc "github.com/auto-dns/pihole-cluster-admin/internal/service/user"
 	"github.com/auto-dns/pihole-cluster-admin/internal/sessions"
 	"github.com/auto-dns/pihole-cluster-admin/internal/store"
@@ -100,6 +101,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	piholeService := piholesvc.NewService(cluster, piholeStore, logger)
 	queryLogService := querylogsvc.NewService(cluster, logger)
 	setupService := setupsvc.NewService(initializationStatusStore, userStore, sessionManager, txProvider, logger)
+	syncService := syncsvc.NewService(cluster, auditLogService, logger)
 	userService := usersvc.NewService(userStore, logger)
 	// Middleware
 	requireAuthMiddleware := middleware.RequireAuth(middleware.AuthDeps{
@@ -150,6 +152,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 		PiholeService:          piholeService,
 		QueryLogService:        queryLogService,
 		SetupService:           setupService,
+		SyncService:            syncService,
 		UserService:            userService,
 		HttpCookieFactory:      cookieFactory,
 		AuthMW:                 requireAuthMiddleware,

--- a/backend/internal/domain/auditlog.go
+++ b/backend/internal/domain/auditlog.go
@@ -9,6 +9,7 @@ const (
 	AuditActionRemoveDomainRule   AuditAction = "remove_domain_rule"
 	AuditActionSetClusterBlocking AuditAction = "set_cluster_blocking"
 	AuditActionSetNodeBlocking    AuditAction = "set_node_blocking"
+	AuditActionSyncFromNode       AuditAction = "sync_from_node"
 )
 
 type AuditNodeResult struct {

--- a/backend/internal/domain/sync.go
+++ b/backend/internal/domain/sync.go
@@ -1,0 +1,10 @@
+package domain
+
+type SyncNodeResult struct {
+	NodeId   int64
+	NodeName string
+	Added    int
+	Removed  int
+	Success  bool
+	Error    string
+}

--- a/backend/internal/http/api/v1/interface.go
+++ b/backend/internal/http/api/v1/interface.go
@@ -59,6 +59,10 @@ type setupService interface {
 	UpdatePiholeInitializationStatus(params setupsvc.UpdatePiholeInitializationStatusCommand) error
 }
 
+type syncService interface {
+	SyncFromNode(ctx context.Context, sourceNodeId int64) ([]domain.SyncNodeResult, error)
+}
+
 type userService interface {
 	Patch(id int64, params usersvc.PatchUserCommand) (*domain.User, error)
 	UpdatePassword(id int64, params usersvc.UpdatePasswordCommand) (*domain.User, error)

--- a/backend/internal/http/api/v1/router.go
+++ b/backend/internal/http/api/v1/router.go
@@ -17,6 +17,7 @@ type Deps struct {
 	PiholeService          piholeService
 	QueryLogService        queryLogService
 	SetupService           setupService
+	SyncService            syncService
 	UserService            userService
 
 	// Other dependencies
@@ -48,6 +49,7 @@ func RegisterAPIV1(r chi.Router, d Deps) {
 		registerPihole(r, d)
 		registerQueryLog(r, d)
 		registerSetupPrivate(r, d)
+		registerSync(r, d)
 		registerUser(r, d)
 	})
 }

--- a/backend/internal/http/api/v1/sync_dto.go
+++ b/backend/internal/http/api/v1/sync_dto.go
@@ -1,0 +1,32 @@
+package v1
+
+import "github.com/auto-dns/pihole-cluster-admin/internal/domain"
+
+type syncRequestDTO struct {
+	SourceNodeId int64 `json:"sourceNodeId"`
+}
+
+type syncResponseDTO struct {
+	SourceNodeId int64               `json:"sourceNodeId"`
+	Nodes        []syncNodeResultDTO `json:"nodes"`
+}
+
+type syncNodeResultDTO struct {
+	NodeId   int64  `json:"nodeId"`
+	NodeName string `json:"nodeName"`
+	Added    int    `json:"added"`
+	Removed  int    `json:"removed"`
+	Success  bool   `json:"success"`
+	Error    string `json:"error,omitempty"`
+}
+
+func toSyncNodeResultDTO(r domain.SyncNodeResult) syncNodeResultDTO {
+	return syncNodeResultDTO{
+		NodeId:   r.NodeId,
+		NodeName: r.NodeName,
+		Added:    r.Added,
+		Removed:  r.Removed,
+		Success:  r.Success,
+		Error:    r.Error,
+	}
+}

--- a/backend/internal/http/api/v1/sync_handlers.go
+++ b/backend/internal/http/api/v1/sync_handlers.go
@@ -1,0 +1,50 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/errs"
+	"github.com/auto-dns/pihole-cluster-admin/internal/http/transport"
+	"github.com/go-chi/chi"
+)
+
+func registerSync(r chi.Router, d Deps) {
+	r.Post("/sync", syncFromNode(d))
+}
+
+func syncFromNode(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body syncRequestDTO
+		if err := transport.DecodeJSONBody(w, r, &body, 1<<20); err != nil {
+			transport.WriteErr(w, err)
+			return
+		}
+		if body.SourceNodeId <= 0 {
+			transport.WriteBadRequestErr(w, "sourceNodeId is required", nil)
+			return
+		}
+
+		results, err := d.SyncService.SyncFromNode(r.Context(), body.SourceNodeId)
+		if err != nil {
+			if errs.KindOf(err) == errs.KindNotFound {
+				transport.WriteNotFoundErr(w, "source node not found")
+			} else if errs.KindOf(err) == errs.KindUnavailable {
+				transport.WriteErr(w, err)
+			} else {
+				d.Logger.Error().Err(err).Msg("sync from node failed")
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+			}
+			return
+		}
+
+		dtos := make([]syncNodeResultDTO, 0, len(results))
+		for _, r := range results {
+			dtos = append(dtos, toSyncNodeResultDTO(r))
+		}
+
+		transport.WriteJSON(w, http.StatusOK, syncResponseDTO{
+			SourceNodeId: body.SourceNodeId,
+			Nodes:        dtos,
+		})
+	}
+}

--- a/backend/internal/migrations/003_sync_action.down.sql
+++ b/backend/internal/migrations/003_sync_action.down.sql
@@ -1,0 +1,24 @@
+-- Revert: remove sync_from_node from the action CHECK constraint.
+CREATE TABLE audit_log_new (
+    id              INTEGER  PRIMARY KEY AUTOINCREMENT,
+    actor           TEXT     NOT NULL,
+    action          TEXT     NOT NULL CHECK (action IN (
+                        'add_domain_rule',
+                        'remove_domain_rule',
+                        'set_cluster_blocking',
+                        'set_node_blocking'
+                    )),
+    target_domain   TEXT,
+    rule_type       TEXT,
+    rule_kind       TEXT,
+    blocking_enabled INTEGER,
+    blocking_timer  INTEGER,
+    target_node_id  INTEGER,
+    target_node_name TEXT,
+    node_results    TEXT     NOT NULL DEFAULT '[]',
+    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO audit_log_new SELECT * FROM audit_log WHERE action != 'sync_from_node';
+DROP TABLE audit_log;
+ALTER TABLE audit_log_new RENAME TO audit_log;
+CREATE INDEX IF NOT EXISTS audit_log_created_at_idx ON audit_log(created_at);

--- a/backend/internal/migrations/003_sync_action.up.sql
+++ b/backend/internal/migrations/003_sync_action.up.sql
@@ -1,0 +1,26 @@
+-- Expand the action CHECK constraint to include sync_from_node.
+-- SQLite does not support ALTER COLUMN, so we recreate the table.
+CREATE TABLE audit_log_new (
+    id              INTEGER  PRIMARY KEY AUTOINCREMENT,
+    actor           TEXT     NOT NULL,
+    action          TEXT     NOT NULL CHECK (action IN (
+                        'add_domain_rule',
+                        'remove_domain_rule',
+                        'set_cluster_blocking',
+                        'set_node_blocking',
+                        'sync_from_node'
+                    )),
+    target_domain   TEXT,
+    rule_type       TEXT,
+    rule_kind       TEXT,
+    blocking_enabled INTEGER,
+    blocking_timer  INTEGER,
+    target_node_id  INTEGER,
+    target_node_name TEXT,
+    node_results    TEXT     NOT NULL DEFAULT '[]',
+    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO audit_log_new SELECT * FROM audit_log;
+DROP TABLE audit_log;
+ALTER TABLE audit_log_new RENAME TO audit_log;
+CREATE INDEX IF NOT EXISTS audit_log_created_at_idx ON audit_log(created_at);

--- a/backend/internal/pihole/cluster.go
+++ b/backend/internal/pihole/cluster.go
@@ -337,6 +337,75 @@ func (c *Cluster) RemoveDomainRule(ctx context.Context, cmd domain.RemoveDomainR
 	return out
 }
 
+func (c *Cluster) AddDomainRuleToNodes(ctx context.Context, cmd domain.AddDomainRulesCommand, nodeIDs []int64) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult] {
+	targets := c.filterClients(nodeIDs)
+	out := make(map[int64]*domain.NodeResult[*domain.AddDomainRulesResult], len(targets))
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	for id, cl := range targets {
+		id, cl := id, cl
+		g.Go(func() error {
+			nodeCtx, cancel := context.WithTimeout(gctx, 3*time.Second)
+			defer cancel()
+			resp, err := cl.AddDomainRule(nodeCtx, cmd)
+			if err != nil {
+				err = mapClientErr(err)
+			}
+			mu.Lock()
+			out[id] = &domain.NodeResult[*domain.AddDomainRulesResult]{
+				PiholeNode: cl.GetNodeInfo(nodeCtx),
+				Success:    err == nil,
+				Error:      err,
+				Response:   resp,
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+	_ = g.Wait()
+	return out
+}
+
+func (c *Cluster) RemoveDomainRuleFromNodes(ctx context.Context, cmd domain.RemoveDomainRuleCommand, nodeIDs []int64) map[int64]*domain.NodeResult[struct{}] {
+	targets := c.filterClients(nodeIDs)
+	out := make(map[int64]*domain.NodeResult[struct{}], len(targets))
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	for id, cl := range targets {
+		id, cl := id, cl
+		g.Go(func() error {
+			nodeCtx, cancel := context.WithTimeout(gctx, 3*time.Second)
+			defer cancel()
+			err := cl.RemoveDomainRule(nodeCtx, cmd)
+			if err != nil {
+				err = mapClientErr(err)
+			}
+			mu.Lock()
+			out[id] = &domain.NodeResult[struct{}]{
+				PiholeNode: cl.GetNodeInfo(nodeCtx),
+				Success:    err == nil,
+				Error:      err,
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+	_ = g.Wait()
+	return out
+}
+
+func (c *Cluster) filterClients(nodeIDs []int64) map[int64]clientPort {
+	c.rw.RLock()
+	defer c.rw.RUnlock()
+	targets := make(map[int64]clientPort, len(nodeIDs))
+	for _, id := range nodeIDs {
+		if cl, ok := c.clients[id]; ok {
+			targets[id] = cl
+		}
+	}
+	return targets
+}
+
 func (c *Cluster) AuthStatus(ctx context.Context) map[int64]*domain.NodeResult[*domain.AuthStatus] {
 	c.logger.Trace().Msg("getting auth status for cluster")
 	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.AuthStatus, error) {

--- a/backend/internal/service/sync/interface.go
+++ b/backend/internal/service/sync/interface.go
@@ -1,0 +1,17 @@
+package syncsvc
+
+import (
+	"context"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+)
+
+type syncCluster interface {
+	ListDomainRules(ctx context.Context, q domain.ListDomainRulesQuery) map[int64]*domain.NodeResult[*domain.DomainRuleSet]
+	AddDomainRuleToNodes(ctx context.Context, cmd domain.AddDomainRulesCommand, nodeIDs []int64) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult]
+	RemoveDomainRuleFromNodes(ctx context.Context, cmd domain.RemoveDomainRuleCommand, nodeIDs []int64) map[int64]*domain.NodeResult[struct{}]
+}
+
+type auditLogger interface {
+	Record(ctx context.Context, params domain.CreateAuditEntryParams)
+}

--- a/backend/internal/service/sync/service.go
+++ b/backend/internal/service/sync/service.go
@@ -1,0 +1,158 @@
+package syncsvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/errs"
+	"github.com/rs/zerolog"
+)
+
+type Service struct {
+	cluster syncCluster
+	audit   auditLogger
+	logger  zerolog.Logger
+}
+
+func NewService(cluster syncCluster, audit auditLogger, logger zerolog.Logger) *Service {
+	return &Service{cluster: cluster, audit: audit, logger: logger}
+}
+
+type ruleKey struct {
+	Type   domain.RuleType
+	Kind   domain.RuleKind
+	Domain string
+}
+
+type typeKindKey struct {
+	Type domain.RuleType
+	Kind domain.RuleKind
+}
+
+func (s *Service) SyncFromNode(ctx context.Context, sourceNodeId int64) ([]domain.SyncNodeResult, error) {
+	allRules := s.cluster.ListDomainRules(ctx, domain.ListDomainRulesQuery{})
+
+	source, ok := allRules[sourceNodeId]
+	if !ok {
+		return nil, errs.NotFound("source node not found", fmt.Errorf("node %d not found", sourceNodeId))
+	}
+	if !source.Success || source.Response == nil {
+		return nil, errs.Unavailable("could not fetch rules from source node", source.Error)
+	}
+
+	sourceRules := source.Response.Rules
+	sourceName := source.PiholeNode.Name
+
+	// Index source rules by key for fast lookup
+	sourceSet := make(map[ruleKey]bool, len(sourceRules))
+	for _, r := range sourceRules {
+		sourceSet[ruleKey{r.Type, r.Kind, r.Domain}] = true
+	}
+
+	results := make([]domain.SyncNodeResult, 0, len(allRules)-1)
+
+	for nodeId, nodeResult := range allRules {
+		if nodeId == sourceNodeId {
+			continue
+		}
+
+		res := domain.SyncNodeResult{
+			NodeId:   nodeId,
+			NodeName: nodeResult.PiholeNode.Name,
+		}
+
+		if !nodeResult.Success || nodeResult.Response == nil {
+			res.Error = fmt.Sprintf("failed to fetch rules: %v", nodeResult.Error)
+			results = append(results, res)
+			continue
+		}
+
+		targetRules := nodeResult.Response.Rules
+
+		// Index target rules
+		targetSet := make(map[ruleKey]bool, len(targetRules))
+		for _, r := range targetRules {
+			targetSet[ruleKey{r.Type, r.Kind, r.Domain}] = true
+		}
+
+		// Compute diff
+		var toAdd []domain.DomainRule
+		for _, r := range sourceRules {
+			if !targetSet[ruleKey{r.Type, r.Kind, r.Domain}] {
+				toAdd = append(toAdd, r)
+			}
+		}
+		var toRemove []domain.DomainRule
+		for _, r := range targetRules {
+			if !sourceSet[ruleKey{r.Type, r.Kind, r.Domain}] {
+				toRemove = append(toRemove, r)
+			}
+		}
+
+		// Add missing rules (grouped by type+kind for batching)
+		addGroups := make(map[typeKindKey][]string)
+		for _, r := range toAdd {
+			k := typeKindKey{r.Type, r.Kind}
+			addGroups[k] = append(addGroups[k], r.Domain)
+		}
+		for k, domains := range addGroups {
+			addResults := s.cluster.AddDomainRuleToNodes(ctx, domain.AddDomainRulesCommand{
+				Type:    k.Type,
+				Kind:    k.Kind,
+				Domains: domains,
+			}, []int64{nodeId})
+			if nr, exists := addResults[nodeId]; exists {
+				if nr.Success {
+					res.Added += len(domains)
+				} else if nr.Error != nil {
+					if res.Error != "" {
+						res.Error += "; "
+					}
+					res.Error += nr.Error.Error()
+				}
+			}
+		}
+
+		// Remove extra rules (one at a time)
+		for _, r := range toRemove {
+			removeResults := s.cluster.RemoveDomainRuleFromNodes(ctx, domain.RemoveDomainRuleCommand{
+				Type:   r.Type,
+				Kind:   r.Kind,
+				Domain: r.Domain,
+			}, []int64{nodeId})
+			if nr, exists := removeResults[nodeId]; exists {
+				if nr.Success {
+					res.Removed++
+				} else if nr.Error != nil {
+					if res.Error != "" {
+						res.Error += "; "
+					}
+					res.Error += nr.Error.Error()
+				}
+			}
+		}
+
+		res.Success = res.Error == ""
+		results = append(results, res)
+	}
+
+	// Record a single audit entry for the sync operation
+	auditResults := make([]domain.AuditNodeResult, len(results))
+	for i, r := range results {
+		auditResults[i] = domain.AuditNodeResult{
+			NodeId:   r.NodeId,
+			NodeName: r.NodeName,
+			Success:  r.Success,
+			Error:    r.Error,
+		}
+	}
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:         domain.AuditActionSyncFromNode,
+		TargetNodeId:   &sourceNodeId,
+		TargetNodeName: &sourceName,
+		NodeResults:    auditResults,
+	})
+
+	return results, nil
+}

--- a/frontend/src/lib/api/sync.ts
+++ b/frontend/src/lib/api/sync.ts
@@ -1,0 +1,9 @@
+import { apiV1Fetch } from './client';
+import type { SyncResponse } from '@/types/sync';
+
+export async function syncFromNode(sourceNodeId: number): Promise<SyncResponse> {
+	return apiV1Fetch<SyncResponse>('/sync', {
+		method: 'POST',
+		body: JSON.stringify({ sourceNodeId }),
+	});
+}

--- a/frontend/src/pages/Audit.module.scss
+++ b/frontend/src/pages/Audit.module.scss
@@ -175,6 +175,11 @@
 		background: color-mix(in oklab, var(--accent-primary) 12%, transparent);
 		color: var(--accent-primary);
 	}
+
+	&[data-action='sync_from_node'] {
+		background: color-mix(in oklab, var(--accent-warn) 12%, transparent);
+		color: var(--accent-warn);
+	}
 }
 
 // ---- Status icons ----

--- a/frontend/src/pages/Audit.tsx
+++ b/frontend/src/pages/Audit.tsx
@@ -9,6 +9,7 @@ const ACTION_LABELS: Record<AuditAction, string> = {
 	remove_domain_rule: 'Removed domain rule',
 	set_cluster_blocking: 'Set cluster blocking',
 	set_node_blocking: 'Set node blocking',
+	sync_from_node: 'Synced from node',
 };
 
 function actionLabel(action: AuditAction) {
@@ -33,6 +34,8 @@ function entryDescription(entry: AuditEntry): string {
 					? `enabled${entry.blockingTimer ? ` (${entry.blockingTimer}s)` : ''}`
 					: 'disabled'
 			}`;
+		case 'sync_from_node':
+			return `source: ${entry.targetNodeName ?? `node ${entry.targetNodeId}`}`;
 		default:
 			return '—';
 	}

--- a/frontend/src/pages/Domains.module.scss
+++ b/frontend/src/pages/Domains.module.scss
@@ -93,6 +93,133 @@
 	}
 }
 
+// ---- Force-sync button (toolbar) ----
+
+.forceSyncBtn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.2rem;
+	height: 2.2rem;
+	padding: 0 !important;
+	background: var(--btn-surface-bg) !important;
+	color: var(--btn-surface-text) !important;
+	border: 1px solid var(--border-card);
+	border-radius: var(--input-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: var(--btn-surface-bg-hover) !important;
+	}
+}
+
+// ---- Sync panel ----
+
+.syncPanel {
+	background: var(--bg-card);
+	border: 1px solid var(--border-card);
+	border-radius: var(--card-radius);
+	padding: 0.75rem 1rem;
+	margin-bottom: 1rem;
+}
+
+.syncPanelRow {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+	flex-wrap: wrap;
+}
+
+.syncLabel {
+	font-size: 0.875rem;
+	color: var(--text-secondary);
+	white-space: nowrap;
+}
+
+.syncSelect {
+	padding: 0.35rem 0.6rem;
+	font-size: 0.875rem;
+	background: var(--input-bg);
+	color: var(--text-primary);
+	border: 1px solid var(--border-card);
+	border-radius: var(--input-radius);
+	cursor: pointer;
+
+	&:disabled {
+		opacity: 0.6;
+	}
+}
+
+.syncRunBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35rem;
+	padding: 0.35rem 0.85rem;
+	font-size: 0.875rem;
+	background: var(--accent-primary);
+	color: var(--accent-text);
+	border: none;
+	border-radius: var(--input-radius);
+	cursor: pointer;
+	transition: opacity var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+}
+
+.syncPanelError {
+	margin-top: 0.5rem;
+	font-size: 0.85rem;
+	color: var(--accent-danger);
+}
+
+.syncPanelResults {
+	margin-top: 0.6rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+}
+
+.syncResultRow {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.82rem;
+}
+
+.syncResultName {
+	font-weight: 500;
+}
+
+.syncResultDetail {
+	font-size: 0.78rem;
+	color: var(--text-secondary);
+	font-family: monospace;
+}
+
+.syncResultError {
+	color: var(--accent-danger);
+	font-family: monospace;
+	font-size: 0.78rem;
+}
+
+.iconOk {
+	color: var(--accent-success);
+	flex-shrink: 0;
+}
+
+.iconFail {
+	color: var(--accent-danger);
+	flex-shrink: 0;
+}
+
 // ---- Table ----
 
 .tableInfo {

--- a/frontend/src/pages/Domains.tsx
+++ b/frontend/src/pages/Domains.tsx
@@ -1,18 +1,21 @@
 import { useState, useEffect, useCallback } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Plus, Trash2, RefreshCw, X, GitMerge } from 'lucide-react';
+import { Plus, Trash2, RefreshCw, X, GitMerge, CheckCircle, XCircle } from 'lucide-react';
 import {
 	listDomainRules,
 	addDomainRule,
 	removeDomainRule,
 	syncDomainRule,
 } from '@/lib/api/domainrules';
+import { syncFromNode } from '@/lib/api/sync';
+import { usePiholes } from '@/providers/PiholeProvider';
 import type {
 	ConsolidatedRule,
 	RuleType,
 	RuleKind,
 	ListDomainRulesResponse,
 } from '@/types/domainrule';
+import type { SyncNodeResult } from '@/types/sync';
 import styles from './Domains.module.scss';
 
 function consolidate(resp: ListDomainRulesResponse): {
@@ -61,6 +64,7 @@ type AddForm = {
 const DEFAULT_ADD_FORM: AddForm = { domains: '', type: 'deny', kind: 'exact', comment: '' };
 
 export function Domains() {
+	const { piholeNodes } = usePiholes();
 	const [rules, setRules] = useState<ConsolidatedRule[]>([]);
 	const [nodeNames, setNodeNames] = useState<Map<number, string>>(new Map());
 	const [loading, setLoading] = useState(false);
@@ -76,9 +80,17 @@ export function Domains() {
 	const [removing, setRemoving] = useState<string | null>(null);
 	const [removeError, setRemoveError] = useState<string | null>(null);
 
-	const [syncing, setSyncing] = useState<string | null>(null);
+	// Per-rule parity sync state
+	const [syncingRule, setSyncingRule] = useState<string | null>(null);
 	const [syncingAll, setSyncingAll] = useState(false);
-	const [syncError, setSyncError] = useState<string | null>(null);
+	const [ruleSyncError, setRuleSyncError] = useState<string | null>(null);
+
+	// Force-sync (replicate one node's full rule set to all others)
+	const [forceSyncOpen, setForceSyncOpen] = useState(false);
+	const [forceSyncSourceId, setForceSyncSourceId] = useState<number | null>(null);
+	const [forceSyncing, setForceSyncing] = useState(false);
+	const [forceSyncError, setForceSyncError] = useState<string | null>(null);
+	const [forceSyncResults, setForceSyncResults] = useState<SyncNodeResult[] | null>(null);
 
 	const fetchRules = useCallback(async () => {
 		setLoading(true);
@@ -98,6 +110,60 @@ export function Domains() {
 	useEffect(() => {
 		fetchRules();
 	}, [fetchRules]);
+
+	// Default force-sync source to first node
+	useEffect(() => {
+		if (piholeNodes.length > 0 && forceSyncSourceId === null) {
+			setForceSyncSourceId(piholeNodes[0].id);
+		}
+	}, [piholeNodes, forceSyncSourceId]);
+
+	async function handleSyncRule(rule: ConsolidatedRule) {
+		setRuleSyncError(null);
+		setSyncingRule(rule.key);
+		try {
+			await syncDomainRule(rule.type, rule.kind, rule.domain, rule.comment ?? undefined);
+			await fetchRules();
+		} catch (err) {
+			setRuleSyncError(err instanceof Error ? err.message : 'Failed to sync rule');
+		} finally {
+			setSyncingRule(null);
+		}
+	}
+
+	async function handleSyncAll() {
+		setRuleSyncError(null);
+		setSyncingAll(true);
+		try {
+			const partialRules = rules.filter((r) => r.nodeIds.length < r.totalNodes);
+			await Promise.all(
+				partialRules.map((r) =>
+					syncDomainRule(r.type, r.kind, r.domain, r.comment ?? undefined),
+				),
+			);
+			await fetchRules();
+		} catch (err) {
+			setRuleSyncError(err instanceof Error ? err.message : 'Failed to sync rules');
+		} finally {
+			setSyncingAll(false);
+		}
+	}
+
+	async function handleForceSync() {
+		if (!forceSyncSourceId) return;
+		setForceSyncing(true);
+		setForceSyncError(null);
+		setForceSyncResults(null);
+		try {
+			const resp = await syncFromNode(forceSyncSourceId);
+			setForceSyncResults(resp.nodes);
+			await fetchRules();
+		} catch (err) {
+			setForceSyncError(err instanceof Error ? err.message : 'Sync failed');
+		} finally {
+			setForceSyncing(false);
+		}
+	}
 
 	async function handleAdd() {
 		setAddError(null);
@@ -141,37 +207,6 @@ export function Domains() {
 		}
 	}
 
-	async function handleSync(rule: ConsolidatedRule) {
-		setSyncError(null);
-		setSyncing(rule.key);
-		try {
-			await syncDomainRule(rule.type, rule.kind, rule.domain, rule.comment ?? undefined);
-			await fetchRules();
-		} catch (err) {
-			setSyncError(err instanceof Error ? err.message : 'Failed to sync rule');
-		} finally {
-			setSyncing(null);
-		}
-	}
-
-	async function handleSyncAll() {
-		setSyncError(null);
-		setSyncingAll(true);
-		try {
-			const partialRules = rules.filter((r) => r.nodeIds.length < r.totalNodes);
-			await Promise.all(
-				partialRules.map((r) =>
-					syncDomainRule(r.type, r.kind, r.domain, r.comment ?? undefined),
-				),
-			);
-			await fetchRules();
-		} catch (err) {
-			setSyncError(err instanceof Error ? err.message : 'Failed to sync rules');
-		} finally {
-			setSyncingAll(false);
-		}
-	}
-
 	const filtered = typeFilter === 'all' ? rules : rules.filter((r) => r.type === typeFilter);
 	const partialCount = rules.filter((r) => r.nodeIds.length < r.totalNodes).length;
 
@@ -203,6 +238,22 @@ export function Domains() {
 					>
 						<RefreshCw size={16} className={loading ? styles.spin : undefined} />
 					</button>
+
+					{piholeNodes.length > 1 && (
+						<button
+							type='button'
+							className={styles.forceSyncBtn}
+							onClick={() => {
+								setForceSyncOpen((v) => !v);
+								setForceSyncResults(null);
+								setForceSyncError(null);
+							}}
+							aria-label='Sync from node'
+							title='Sync rules from a node to all others'
+						>
+							<GitMerge size={16} />
+						</button>
+					)}
 
 					<Dialog.Root
 						open={addOpen}
@@ -344,9 +395,69 @@ export function Domains() {
 				</div>
 			</div>
 
+			{forceSyncOpen && piholeNodes.length > 1 && (
+				<div className={styles.syncPanel}>
+					<div className={styles.syncPanelRow}>
+						<label htmlFor='sync-source' className={styles.syncLabel}>
+							Sync rules from:
+						</label>
+						<select
+							id='sync-source'
+							className={styles.syncSelect}
+							value={forceSyncSourceId ?? ''}
+							onChange={(e) => setForceSyncSourceId(Number(e.target.value))}
+							disabled={forceSyncing}
+						>
+							{piholeNodes.map((n) => (
+								<option key={n.id} value={n.id}>
+									{n.name}
+								</option>
+							))}
+						</select>
+						<button
+							type='button'
+							className={styles.syncRunBtn}
+							onClick={handleForceSync}
+							disabled={forceSyncing || !forceSyncSourceId}
+							aria-busy={forceSyncing}
+						>
+							{forceSyncing ? (
+								<RefreshCw size={14} className={styles.spin} />
+							) : (
+								<GitMerge size={14} />
+							)}
+							{forceSyncing ? 'Syncing…' : 'Sync'}
+						</button>
+					</div>
+					{forceSyncError && (
+						<div className={styles.syncPanelError}>{forceSyncError}</div>
+					)}
+					{forceSyncResults && (
+						<div className={styles.syncPanelResults}>
+							{forceSyncResults.map((nr) => (
+								<div key={nr.nodeId} className={styles.syncResultRow}>
+									{nr.success ? (
+										<CheckCircle size={13} className={styles.iconOk} />
+									) : (
+										<XCircle size={13} className={styles.iconFail} />
+									)}
+									<span className={styles.syncResultName}>{nr.nodeName}</span>
+									<span className={styles.syncResultDetail}>
+										+{nr.added} / -{nr.removed}
+									</span>
+									{nr.error && (
+										<span className={styles.syncResultError}>{nr.error}</span>
+									)}
+								</div>
+							))}
+						</div>
+					)}
+				</div>
+			)}
+
 			{error && <div className={styles.error}>{error}</div>}
 			{removeError && <div className={styles.error}>{removeError}</div>}
-			{syncError && <div className={styles.error}>{syncError}</div>}
+			{ruleSyncError && <div className={styles.error}>{ruleSyncError}</div>}
 
 			{!loading && !error && partialCount > 0 && (
 				<div className={styles.parityBanner}>
@@ -483,15 +594,15 @@ export function Domains() {
 															<button
 																type='button'
 																className={styles.syncBtn}
-																onClick={() => handleSync(rule)}
+																onClick={() => handleSyncRule(rule)}
 																disabled={
-																	syncing === rule.key ||
+																	syncingRule === rule.key ||
 																	syncingAll
 																}
 																aria-label={`Sync ${rule.domain} to all nodes`}
 																title='Sync to missing nodes'
 															>
-																{syncing === rule.key ? (
+																{syncingRule === rule.key ? (
 																	<RefreshCw
 																		size={13}
 																		className={styles.spin}

--- a/frontend/src/types/audit.ts
+++ b/frontend/src/types/audit.ts
@@ -2,7 +2,8 @@ export type AuditAction =
 	| 'add_domain_rule'
 	| 'remove_domain_rule'
 	| 'set_cluster_blocking'
-	| 'set_node_blocking';
+	| 'set_node_blocking'
+	| 'sync_from_node';
 
 export type AuditNodeResult = {
 	nodeId: number;

--- a/frontend/src/types/sync.ts
+++ b/frontend/src/types/sync.ts
@@ -1,0 +1,13 @@
+export type SyncNodeResult = {
+	nodeId: number;
+	nodeName: string;
+	added: number;
+	removed: number;
+	success: boolean;
+	error?: string;
+};
+
+export type SyncResponse = {
+	sourceNodeId: number;
+	nodes: SyncNodeResult[];
+};


### PR DESCRIPTION
## Summary

- `POST /api/v1/sync` accepts `{ sourceNodeId }` — fetches the source node's complete rule set, computes per-target diffs, adds missing rules, and removes extra rules from every other node
- New `syncsvc` package with `SyncFromNode` method; uses `Cluster.AddDomainRuleToNodes` / `RemoveDomainRuleFromNodes` (targeted fanout to specific node IDs)
- Migration 003 expands the `audit_log` CHECK constraint to allow `sync_from_node` actions; a single audit entry is recorded per sync with per-node success/failure
- GitMerge button in the Domains page toolbar (only visible when ≥ 2 nodes are configured); clicking opens an inline panel with a source-node picker and per-node result display (+added / -removed counts)
- Audit page shows `sync_from_node` entries with an amber badge and "source: \<node name\>" description

Depends on #20 (audit log) being merged first due to migration numbering.

## Test plan

- [ ] With 2+ Pi-hole nodes, open Domains page → verify GitMerge button appears
- [ ] Click GitMerge → verify sync panel opens with a source node picker
- [ ] Add a rule to node A directly via Pi-hole UI → click Sync with node A as source → verify the rule appears on node B
- [ ] Remove a rule from node B directly → Sync from node A → verify rule is re-added to node B
- [ ] Verify per-node result shows correct `+N / -N` counts
- [ ] Verify audit page shows a "Synced from node" entry with the source node name
- [ ] `POST /api/v1/sync` with an unknown `sourceNodeId` → 404
- [ ] `POST /api/v1/sync` with a source node that is unreachable → 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)