### PR TITLE
chore: UI polish — PWA, touch targets, and global style cleanup

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,7 @@
 		/>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-		<title>Pihole Cluster Admin</title>
+		<title>Pi-hole Cluster Admin</title>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -1,6 +1,8 @@
 {
+	"id": "/",
 	"name": "Pi-hole Cluster Admin",
 	"short_name": "PH Cluster",
+	"description": "Manage multiple Pi-hole instances as a single cluster",
 	"start_url": "/",
 	"display": "standalone",
 	"background_color": "#101114",
@@ -9,12 +11,14 @@
 		{
 			"src": "/icon-192.png",
 			"sizes": "192x192",
-			"type": "image/png"
+			"type": "image/png",
+			"purpose": "any"
 		},
 		{
 			"src": "/icon-512.png",
 			"sizes": "512x512",
-			"type": "image/png"
+			"type": "image/png",
+			"purpose": "any maskable"
 		}
 	]
 }

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,25 @@
+const CACHE = 'pca-shell-v1';
+
+self.addEventListener('install', (e) => {
+	e.waitUntil(caches.open(CACHE).then((c) => c.add('/')));
+	self.skipWaiting();
+});
+
+self.addEventListener('activate', (e) => {
+	e.waitUntil(
+		caches
+			.keys()
+			.then((keys) =>
+				Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))),
+			),
+	);
+	self.clients.claim();
+});
+
+// Network-first for navigation requests; serve cached shell when offline.
+// API calls are never intercepted so live data is always fresh.
+self.addEventListener('fetch', (e) => {
+	if (e.request.url.includes('/api/')) return;
+	if (e.request.mode !== 'navigate') return;
+	e.respondWith(fetch(e.request).catch(() => caches.match('/')));
+});

--- a/frontend/src/components/Layout/AppLayout/AppLayout.module.scss
+++ b/frontend/src/components/Layout/AppLayout/AppLayout.module.scss
@@ -8,7 +8,7 @@
 }
 
 .layout {
-	height: 100vh;
+	height: 100dvh;
 	display: flex;
 	min-width: 0;
 }

--- a/frontend/src/components/Layout/Sidebar/Sidebar.module.scss
+++ b/frontend/src/components/Layout/Sidebar/Sidebar.module.scss
@@ -228,7 +228,7 @@
 		position: fixed;
 		top: var(--toolbar-height); /* below header */
 		left: 0;
-		height: calc(100vh - var(--toolbar-height));
+		height: calc(100dvh - var(--toolbar-height));
 		width: 280px;
 		max-width: 85vw;
 		z-index: 1100;
@@ -259,5 +259,17 @@
 			opacity: 1;
 			pointer-events: auto;
 		}
+	}
+
+	/* Ensure nav items and action buttons meet 44×44px touch target minimum */
+	.navItem,
+	.logoutBtn {
+		min-height: 44px;
+		padding: 12px 10px;
+	}
+
+	.toggleButton {
+		min-width: 44px;
+		min-height: 44px;
 	}
 }

--- a/frontend/src/components/Layout/Toolbar/Toolbar.module.scss
+++ b/frontend/src/components/Layout/Toolbar/Toolbar.module.scss
@@ -25,8 +25,8 @@
 	border: 1px solid var(--border-primary);
 	border-radius: var(--border-radius);
 	padding: 0;
-	width: 36px;
-	height: 36px;
+	width: 44px;
+	height: 44px;
 	align-items: center;
 	justify-content: center;
 	line-height: 0;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,12 @@ import { PiholeProvider } from '@/providers/PiholeProvider';
 import { LayoutProvider } from '@/providers/LayoutProvider';
 import '@/styles/globals.scss';
 
+if ('serviceWorker' in navigator) {
+	window.addEventListener('load', () => {
+		navigator.serviceWorker.register('/sw.js').catch(() => {});
+	});
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
 	<StrictMode>
 		<AuthProvider>

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -13,7 +13,7 @@ html {
 body {
 	margin: 0;
 	padding: 0;
-	min-height: 100%;
+	min-height: 100dvh;
 	overflow-x: hidden;
 	max-width: 100vw;
 	font-size: 1rem;
@@ -87,32 +87,6 @@ textarea {
 	font: inherit;
 }
 
-button {
-	cursor: pointer;
-	border: none;
-	padding: 0.5rem 1rem;
-	border-radius: 0.375rem;
-	background-color: var(--btn-primary-bg);
-	color: var(--btn-primary-text);
-	transition: background-color var(--transition-fast);
-
-	&:hover {
-		background-color: var(--btn-primary-bg-hover);
-	}
-}
-
-button.secondary {
-	background-color: var(--btn-cancel-bg);
-	border: 0.0635rem solid var(--btn-cancel-border);
-	color: var(--btn-cancel-text);
-	transition:
-		background-color var(--transition-fast),
-		border-color var(--transition-fast);
-	&:hover {
-		background-color: var(--btn-cancel-bg-hover);
-	}
-}
-
 input,
 select,
 textarea {
@@ -160,17 +134,6 @@ hr {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-}
-.sr-only {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	padding: 0;
-	margin: -1px;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border: 0;
 }
 
 button {


### PR DESCRIPTION
## Summary

- Add PWA service worker (`sw.js`) with network-first navigation strategy and offline splash support; register in `main.tsx`
- Update `site.webmanifest` with `id`, `description`, and maskable icon purpose for better PWA installability
- Replace `100vh` with `100dvh` throughout layout SCSS to correctly handle dynamic viewport on mobile (avoids Chrome address bar overflow)
- Enforce 44×44px minimum touch targets on mobile: nav items, logout button, hamburger, and sidebar toggle button
- Remove duplicate `button`, `button.secondary`, and `.sr-only` rule blocks from `globals.scss`
- Fix `<title>` capitalisation in `index.html` (`Pihole` → `Pi-hole`)

## Test plan

- [ ] Install as PWA on iOS/Android — verify manifest name, icons, and `display: standalone` work
- [ ] Reload offline — verify service worker serves the shell page without network
- [ ] Resize browser to ≤768px — verify no viewport overflow from address bar
- [ ] Tap hamburger, nav items, and logout on a touch device — verify all targets are comfortably ≥44px
- [ ] Confirm no visual regression on desktop (no duplicate styles, button styles intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)