### PR TITLE
chore: add CHANGELOG and automate GitHub releases from CI

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      contents: read
+      contents: write
       packages: write
       attestations: write
       id-token: write
@@ -77,3 +77,31 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push-full.outputs.digest }}
           push-to-registry: true
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          prerelease="${{ steps.version.outputs.prerelease }}"
+
+          # Extract the matching section from CHANGELOG.md
+          body=$(awk "/^## \[$version\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md | sed '/^$/N;/^\n$/d')
+
+          # Append Docker image reference
+          body="${body}
+
+## Docker image
+
+\`\`\`
+docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${version}
+\`\`\`
+"
+
+          prerelease_flag=""
+          [ -n "$prerelease" ] && prerelease_flag="--prerelease"
+
+          gh release create "v${version}" \
+            --title "v${version}" \
+            --notes "$body" \
+            $prerelease_flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,152 @@
+# Changelog
+
+All notable changes to this project are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0] - 2026-05-16
+
+### Added
+- **Audit log** — every domain rule add/remove and blocking enable/disable is recorded with a timestamp, actor, and per-node result. New `/audit` page shows a paginated history with inline result badges.
+- **Rollback** — each audit entry has an Undo button that runs the inverse operation cluster-wide (add→remove, remove→add) and shows per-node results inline.
+- **Force sync** — new "Sync from node" panel on the Domains page replicates one node's full rule set to all others on demand, with per-node added/removed counts.
+- **Node parity** — partial-coverage domain rules (present on some nodes but not all) are now flagged with an amber badge. A parity banner offers one-click "Sync all" and individual rules show a per-row sync button.
+- **Service worker** — offline splash support; network-first navigation strategy.
+
+### Changed
+- Layout uses `100dvh` throughout — fixes address-bar viewport overflow on mobile browsers.
+- Touch targets raised to 44×44 px minimum (WCAG 2.1 AA) on nav items, hamburger, logout button, and sidebar toggle.
+- `site.webmanifest` updated with `id`, `description`, and maskable icon for better PWA installability.
+
+### Fixed
+- `<title>` capitalisation corrected to "Pi-hole Cluster Admin".
+- Removed duplicate `button`, `button.secondary`, and `.sr-only` rule blocks from global styles.
+
+## [0.3.6] - 2026-05-15
+
+### Changed
+- README completely rewritten to reflect current architecture: deployment model, environment variables, MCP integration, and Docker usage.
+
+## [0.3.5] - 2026-05-15
+
+### Added
+- CSRF protection via double-submit cookie pattern. Server sets a `csrf_token` cookie on login; frontend reads it and attaches it as `X-CSRF-Token` on all mutating requests. Backend middleware validates the header on POST/PUT/DELETE/PATCH.
+
+## [0.3.4] - 2026-05-15
+
+### Changed
+- Go upgraded from 1.25 to 1.26.3.
+
+## [0.3.3] - 2026-05-15
+
+### Fixed
+- Blocking status indicator no longer briefly shows "degraded" (red triangle) during the ~200 ms before the first SSE event arrives after page load.
+
+## [0.3.2] - 2026-05-15
+
+### Fixed
+- MCP query log tool now paginates correctly and passes all filter parameters (client, type, status) through to Pi-hole.
+
+## [0.3.1] - 2026-05-15
+
+### Fixed
+- MCP server now binds to `0.0.0.0` instead of loopback; network isolation is handled at the Docker Compose level.
+
+## [0.3.0] - 2026-05-15
+
+### Added
+- **MCP server** (Phase 3) — exposes Pi-hole cluster management via the Model Context Protocol. Tools: `get_cluster_health`, `get_blocking_status`, `set_cluster_blocking`, `set_node_blocking`, `get_query_logs`, `list_domain_rules`, `add_domain_rule`, `remove_domain_rule`.
+
+## [0.2.5] - 2026-05-15
+
+### Added
+- **Recent Blocks page** (Phase 2e) — live feed of recently blocked domains across the cluster with one-click allow buttons for fast DNS troubleshooting.
+
+## [0.2.4] - 2026-05-14
+
+### Fixed
+- Remove, refresh, and close buttons on the Domains page were invisible (white text on white background) due to a global button style collision.
+
+## [0.2.3] - 2026-05-14
+
+### Fixed
+- Row expand button icon in the Query Logs table was invisible due to global button padding override.
+
+## [0.2.2] - 2026-05-14
+
+### Fixed
+- Query Logs table expand/collapse used chevron icons that were hard to distinguish; replaced with plus/minus icons.
+
+## [0.2.1] - 2026-05-14
+
+### Fixed
+- Query Logs page: scrolling restored; filter inputs and buttons now visible and functional.
+
+## [0.2.0] - 2026-05-14
+
+### Added
+- **Home / Dashboard page** (Phase 2a) — cluster health grid with per-node blocking status, query counts, and live SSE updates.
+- **Query Logs page** (Phase 2b) — unified paginated log across all cluster nodes with filters (domain, client, type, status), one-click block/allow buttons, and per-entry node attribution.
+- **Domains page** (Phase 2c) — cluster-wide block/allow list management; rules show per-node coverage, with add and remove actions propagated to all nodes.
+- **Cluster blocking page** (Phase 2d) — toggle blocking on/off per node or across the whole cluster, with a countdown timer for timed disabling.
+
+## [0.1.9] - 2026-05-14
+
+### Fixed
+- Pihole node status lights now appear correctly on the first node added, without requiring a page refresh.
+
+## [0.1.8] - 2026-05-14
+
+### Fixed
+- Health check endpoint (`/health`) no longer emits a log line on every poll, reducing noise in production logs.
+
+## [0.1.7] - 2026-05-13
+
+### Fixed
+- SPA deep-links (direct navigation to `/domains`, `/logs`, etc.) now serve `index.html` instead of returning 404.
+
+## [0.1.6] - 2026-05-13
+
+### Fixed
+- Pi-hole API requests now retry on network errors (connection refused, timeout) with exponential backoff, improving resilience during transient node unavailability.
+
+## [0.1.5] - 2026-05-13
+
+### Fixed
+- Corrected embedded filesystem sub-path for frontend assets; the binary now serves the UI correctly in production mode.
+
+## [0.1.4] - 2026-05-13
+
+### Fixed
+- Frontend assets are now served from the root router instead of the API router, fixing 404s on direct navigation.
+- Removed deprecated `install` option from `setup-buildx-action` in CI.
+
+## [0.1.3] - 2026-05-13
+
+### Fixed
+- CI now builds the frontend on native platform (not via QEMU emulation) to avoid sporadic `SIGILL` failures on arm64.
+
+## [0.1.2] - 2026-05-13
+
+### Fixed
+- Upgraded backend Docker builder image to `golang:1.25` to match `go.mod`.
+- Fixed Alpine release image package name (`bind-tools` → correct package for `dig`/`nslookup`).
+
+## [0.1.1] - 2026-05-13
+
+### Changed
+- Bumped Go and npm dependencies to address Dependabot vulnerability alerts.
+
+## [0.1.0] - 2026-05-13
+
+### Added
+- Initial public release. Full-stack web application for managing multiple Pi-hole v6 instances as a single cluster.
+- First-run setup wizard: create admin user, add Pi-hole nodes with connectivity test.
+- Session-based authentication with SQLite-backed sessions.
+- Real-time cluster health monitoring via Server-Sent Events.
+- Cluster-wide blocking toggle with per-node control and countdown timer.
+- Go backend (chi router, SQLite, golang-migrate), React 19 + TypeScript frontend (Vite, SCSS Modules).
+- Docker image published to `ghcr.io/auto-dns/pihole-cluster-admin`.
+- CI workflow builds multi-platform images (amd64, arm64, arm/v7) on tag push.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,15 +103,31 @@ gh pr create --title "..." --body "..."
 
 ## Releasing
 
-Releases are tag-driven. Pushing a `v*.*.*` tag triggers CI (`.github/workflows/docker.yaml`) to build and push the Docker image to `ghcr.io/auto-dns/pihole-cluster-admin`.
+Releases are tag-driven. Pushing a `v*.*.*` tag triggers CI (`.github/workflows/docker.yaml`) to:
+1. Build and push the Docker image to `ghcr.io/auto-dns/pihole-cluster-admin`
+2. Create a GitHub release automatically from the matching `CHANGELOG.md` section
 
 Tags on `main` only. Stable releases use `vMAJOR.MINOR.PATCH`; pre-releases use `vMAJOR.MINOR.PATCH-suffix`.
 
+### Release checklist
+
 ```bash
-# After merging to main:
+# 1. Update CHANGELOG.md on main (via PR):
+#    - Change "## [Unreleased]" → "## [X.Y.Z] - YYYY-MM-DD"
+#    - Add a new empty "## [Unreleased]" section at the top
+
+# 2. After the CHANGELOG PR merges, tag main:
 git checkout main && git pull
-git tag -a v0.X.Y -m "<summary of changes>"
-git push origin v0.X.Y
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
 ```
 
-The workflow tags `ghcr.io/auto-dns/pihole-cluster-admin:latest` and rolling `MAJOR.MINOR` / `MAJOR` aliases for stable releases only (no suffix).
+CI then:
+- Builds multi-platform image (amd64, arm64, arm/v7)
+- Pushes `ghcr.io/auto-dns/pihole-cluster-admin:X.Y.Z`
+- For stable releases: also updates `:X.Y`, `:X`, and `:latest`
+- Creates a GitHub release with the CHANGELOG section + Docker pull command
+
+### CHANGELOG format
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with sub-sections `Added`, `Changed`, `Fixed`, `Removed`, `Security`. The CI release step extracts the `## [X.Y.Z]` section by version number — the section heading must match `## [X.Y.Z]` exactly (no `v` prefix).


### PR DESCRIPTION
## Summary

- Add \`CHANGELOG.md\` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, backfilled for all releases from v0.1.0 through v0.4.0
- Update CI workflow to automatically create a GitHub release on tag push, extracting the matching version section from \`CHANGELOG.md\` and appending the Docker pull command
- Bump \`contents: read\` → \`contents: write\` in workflow permissions (required to create releases)
- Update \`CLAUDE.md\` releasing section with full checklist and CHANGELOG format requirements

## Test plan

- [ ] On next tag push, verify CI creates the GitHub release with correct CHANGELOG section and Docker image reference
- [ ] Verify \`## [Unreleased]\` section is present and CHANGELOG format parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)