### PR TITLE
feat: Stats & Analytics page (Phase 6a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Stats & Analytics page** (`/stats`) — cluster-wide query volume, blocked percentage, gravity size, and unique client count summary cards; query history line chart (allowed vs. blocked) with 1h / 6h / 24h time range presets; top queried and top blocked domain tables; top clients table; per-node breakdown section when more than one node is configured.
+- **Home page stats mini-cards** — total queries, blocked percentage, and gravity size sourced from the cluster summary, with a "View all →" link to `/stats`.
+- **Stats sidebar entry** — "Stats" nav item with a bar-chart icon added between Domains and Audit Log.
+
 ## [0.4.1] - 2026-05-16
 
 ### Fixed

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -27,6 +27,7 @@ import (
 	piholesvc "github.com/auto-dns/pihole-cluster-admin/internal/service/pihole"
 	querylogsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/querylog"
 	setupsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/setup"
+	statssvc "github.com/auto-dns/pihole-cluster-admin/internal/service/stats"
 	syncsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/sync"
 	usersvc "github.com/auto-dns/pihole-cluster-admin/internal/service/user"
 	"github.com/auto-dns/pihole-cluster-admin/internal/sessions"
@@ -100,6 +101,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	healthService := healthsvc.NewService(broker, cluster, cfg.Publishers.Health, logger)
 	piholeService := piholesvc.NewService(cluster, piholeStore, logger)
 	queryLogService := querylogsvc.NewService(cluster, logger)
+	statsService := statssvc.NewService(cluster, logger)
 	setupService := setupsvc.NewService(initializationStatusStore, userStore, sessionManager, txProvider, logger)
 	syncService := syncsvc.NewService(cluster, auditLogService, logger)
 	userService := usersvc.NewService(userStore, logger)
@@ -151,6 +153,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 		HealthService:          healthService,
 		PiholeService:          piholeService,
 		QueryLogService:        queryLogService,
+		StatsService:           statsService,
 		SetupService:           setupService,
 		SyncService:            syncService,
 		UserService:            userService,

--- a/backend/internal/domain/stats.go
+++ b/backend/internal/domain/stats.go
@@ -9,7 +9,6 @@ type StatsSummary struct {
 	GravitySize    int64
 	UniqueClients  int64
 	UniqueDomains  int64
-	Took           time.Duration
 }
 
 type StatsHistoryPoint struct {
@@ -20,7 +19,6 @@ type StatsHistoryPoint struct {
 
 type StatsHistory struct {
 	Points []StatsHistoryPoint
-	Took   time.Duration
 }
 
 type TopDomainEntry struct {
@@ -31,7 +29,6 @@ type TopDomainEntry struct {
 type StatsTopDomains struct {
 	TopQueried []TopDomainEntry
 	TopBlocked []TopDomainEntry
-	Took       time.Duration
 }
 
 type TopClientEntry struct {
@@ -42,7 +39,6 @@ type TopClientEntry struct {
 
 type StatsTopClients struct {
 	Clients []TopClientEntry
-	Took    time.Duration
 }
 
 type ClusterStatsSummary struct {

--- a/backend/internal/domain/stats.go
+++ b/backend/internal/domain/stats.go
@@ -1,0 +1,67 @@
+package domain
+
+import "time"
+
+type StatsSummary struct {
+	QueriesTotal   int64
+	QueriesBlocked int64
+	BlockedPercent float64
+	GravitySize    int64
+	UniqueClients  int64
+	UniqueDomains  int64
+	Took           time.Duration
+}
+
+type StatsHistoryPoint struct {
+	Timestamp time.Time
+	Total     int64
+	Blocked   int64
+}
+
+type StatsHistory struct {
+	Points []StatsHistoryPoint
+	Took   time.Duration
+}
+
+type TopDomainEntry struct {
+	Domain string
+	Count  int64
+}
+
+type StatsTopDomains struct {
+	TopQueried []TopDomainEntry
+	TopBlocked []TopDomainEntry
+	Took       time.Duration
+}
+
+type TopClientEntry struct {
+	IP    string
+	Name  string
+	Count int64
+}
+
+type StatsTopClients struct {
+	Clients []TopClientEntry
+	Took    time.Duration
+}
+
+type ClusterStatsSummary struct {
+	Cluster StatsSummary
+	Nodes   map[int64]*NodeResult[*StatsSummary]
+}
+
+type ClusterStatsHistory struct {
+	ClusterPoints []StatsHistoryPoint
+	Nodes         map[int64]*NodeResult[*StatsHistory]
+}
+
+type ClusterStatsTopDomains struct {
+	ClusterTopQueried []TopDomainEntry
+	ClusterTopBlocked []TopDomainEntry
+	Nodes             map[int64]*NodeResult[*StatsTopDomains]
+}
+
+type ClusterStatsTopClients struct {
+	ClusterClients []TopClientEntry
+	Nodes          map[int64]*NodeResult[*StatsTopClients]
+}

--- a/backend/internal/http/api/v1/interface.go
+++ b/backend/internal/http/api/v1/interface.go
@@ -52,6 +52,13 @@ type queryLogService interface {
 	Fetch(ctx context.Context, req domain.QueryLogQuery) (*domain.ClusterQueryLogResponse, error)
 }
 
+type statsService interface {
+	GetSummary(ctx context.Context) (*domain.ClusterStatsSummary, error)
+	GetHistory(ctx context.Context, from, until *int64) (*domain.ClusterStatsHistory, error)
+	GetTopDomains(ctx context.Context, from, until *int64, count *int) (*domain.ClusterStatsTopDomains, error)
+	GetTopClients(ctx context.Context, from, until *int64, count *int) (*domain.ClusterStatsTopClients, error)
+}
+
 type setupService interface {
 	IsInitialized() (bool, error)
 	CreateUser(ctx context.Context, params setupsvc.CreateUserCommand) (*domain.User, string, error)

--- a/backend/internal/http/api/v1/router.go
+++ b/backend/internal/http/api/v1/router.go
@@ -16,6 +16,7 @@ type Deps struct {
 	HealthService          healthService
 	PiholeService          piholeService
 	QueryLogService        queryLogService
+	StatsService           statsService
 	SetupService           setupService
 	SyncService            syncService
 	UserService            userService
@@ -48,6 +49,7 @@ func RegisterAPIV1(r chi.Router, d Deps) {
 		registerDomainRules(r, d)
 		registerPihole(r, d)
 		registerQueryLog(r, d)
+		registerStats(r, d)
 		registerSetupPrivate(r, d)
 		registerSync(r, d)
 		registerUser(r, d)

--- a/backend/internal/http/api/v1/stats_dto.go
+++ b/backend/internal/http/api/v1/stats_dto.go
@@ -1,0 +1,253 @@
+package v1
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"time"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/errs"
+	"github.com/auto-dns/pihole-cluster-admin/internal/util"
+)
+
+// -- Summary
+
+type statsSummaryResponseDTO struct {
+	Cluster statsSummaryDTO  `json:"cluster"`
+	Nodes   []statsNodeDTO[statsSummaryDTO] `json:"nodes"`
+}
+
+type statsSummaryDTO struct {
+	QueriesTotal   int64   `json:"queriesTotal"`
+	QueriesBlocked int64   `json:"queriesBlocked"`
+	BlockedPercent float64 `json:"blockedPercent"`
+	GravitySize    int64   `json:"gravitySize"`
+	UniqueClients  int64   `json:"uniqueClients"`
+	UniqueDomains  int64   `json:"uniqueDomains"`
+}
+
+func statsSummaryFromDomain(s domain.StatsSummary) statsSummaryDTO {
+	return statsSummaryDTO{
+		QueriesTotal:   s.QueriesTotal,
+		QueriesBlocked: s.QueriesBlocked,
+		BlockedPercent: s.BlockedPercent,
+		GravitySize:    s.GravitySize,
+		UniqueClients:  s.UniqueClients,
+		UniqueDomains:  s.UniqueDomains,
+	}
+}
+
+func statsSummaryResponseFromDomain(res *domain.ClusterStatsSummary) statsSummaryResponseDTO {
+	return statsSummaryResponseDTO{
+		Cluster: statsSummaryFromDomain(res.Cluster),
+		Nodes:   statsNodesFromDomain(res.Nodes, func(s *domain.StatsSummary) statsSummaryDTO {
+			if s == nil {
+				return statsSummaryDTO{}
+			}
+			return statsSummaryFromDomain(*s)
+		}),
+	}
+}
+
+// -- History
+
+type statsHistoryResponseDTO struct {
+	Cluster []statsHistoryPointDTO  `json:"cluster"`
+	Nodes   []statsNodeDTO[[]statsHistoryPointDTO] `json:"nodes"`
+}
+
+type statsHistoryPointDTO struct {
+	Timestamp string `json:"timestamp"`
+	Total     int64  `json:"total"`
+	Blocked   int64  `json:"blocked"`
+}
+
+func statsHistoryPointFromDomain(p domain.StatsHistoryPoint) statsHistoryPointDTO {
+	return statsHistoryPointDTO{
+		Timestamp: rfc3339(p.Timestamp),
+		Total:     p.Total,
+		Blocked:   p.Blocked,
+	}
+}
+
+func statsHistoryPointsFromDomain(points []domain.StatsHistoryPoint) []statsHistoryPointDTO {
+	out := make([]statsHistoryPointDTO, 0, len(points))
+	for _, p := range points {
+		out = append(out, statsHistoryPointFromDomain(p))
+	}
+	return out
+}
+
+func statsHistoryResponseFromDomain(res *domain.ClusterStatsHistory) statsHistoryResponseDTO {
+	return statsHistoryResponseDTO{
+		Cluster: statsHistoryPointsFromDomain(res.ClusterPoints),
+		Nodes: statsNodesFromDomain(res.Nodes, func(h *domain.StatsHistory) []statsHistoryPointDTO {
+			if h == nil {
+				return nil
+			}
+			return statsHistoryPointsFromDomain(h.Points)
+		}),
+	}
+}
+
+// -- Top domains
+
+type statsTopDomainsResponseDTO struct {
+	ClusterTopQueried []topDomainDTO  `json:"clusterTopQueried"`
+	ClusterTopBlocked []topDomainDTO  `json:"clusterTopBlocked"`
+	Nodes             []statsNodeDTO[statsTopDomainsNodePayload] `json:"nodes"`
+}
+
+type statsTopDomainsNodePayload struct {
+	TopQueried []topDomainDTO `json:"topQueried"`
+	TopBlocked []topDomainDTO `json:"topBlocked"`
+}
+
+type topDomainDTO struct {
+	Domain string `json:"domain"`
+	Count  int64  `json:"count"`
+}
+
+func topDomainsFromDomain(entries []domain.TopDomainEntry) []topDomainDTO {
+	out := make([]topDomainDTO, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, topDomainDTO{Domain: e.Domain, Count: e.Count})
+	}
+	return out
+}
+
+func statsTopDomainsResponseFromDomain(res *domain.ClusterStatsTopDomains) statsTopDomainsResponseDTO {
+	return statsTopDomainsResponseDTO{
+		ClusterTopQueried: topDomainsFromDomain(res.ClusterTopQueried),
+		ClusterTopBlocked: topDomainsFromDomain(res.ClusterTopBlocked),
+		Nodes: statsNodesFromDomain(res.Nodes, func(d *domain.StatsTopDomains) statsTopDomainsNodePayload {
+			if d == nil {
+				return statsTopDomainsNodePayload{}
+			}
+			return statsTopDomainsNodePayload{
+				TopQueried: topDomainsFromDomain(d.TopQueried),
+				TopBlocked: topDomainsFromDomain(d.TopBlocked),
+			}
+		}),
+	}
+}
+
+// -- Top clients
+
+type statsTopClientsResponseDTO struct {
+	ClusterClients []topClientDTO  `json:"clusterClients"`
+	Nodes          []statsNodeDTO[[]topClientDTO] `json:"nodes"`
+}
+
+type topClientDTO struct {
+	IP    string `json:"ip"`
+	Name  string `json:"name"`
+	Count int64  `json:"count"`
+}
+
+func topClientsFromDomain(entries []domain.TopClientEntry) []topClientDTO {
+	out := make([]topClientDTO, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, topClientDTO{IP: e.IP, Name: e.Name, Count: e.Count})
+	}
+	return out
+}
+
+func statsTopClientsResponseFromDomain(res *domain.ClusterStatsTopClients) statsTopClientsResponseDTO {
+	return statsTopClientsResponseDTO{
+		ClusterClients: topClientsFromDomain(res.ClusterClients),
+		Nodes: statsNodesFromDomain(res.Nodes, func(c *domain.StatsTopClients) []topClientDTO {
+			if c == nil {
+				return nil
+			}
+			return topClientsFromDomain(c.Clients)
+		}),
+	}
+}
+
+// -- Generic node result wrapper
+
+type statsNodeDTO[T any] struct {
+	Node    piholeNodeRefDTO `json:"node"`
+	Success bool             `json:"success"`
+	Error   string           `json:"error,omitempty"`
+	Data    T                `json:"data"`
+}
+
+func statsNodesFromDomain[R any, T any](
+	nodes map[int64]*domain.NodeResult[R],
+	extract func(R) T,
+) []statsNodeDTO[T] {
+	ids := make([]int64, 0, len(nodes))
+	for id := range nodes {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	out := make([]statsNodeDTO[T], 0, len(nodes))
+	for _, id := range ids {
+		nr := nodes[id]
+		out = append(out, statsNodeDTO[T]{
+			Node: piholeNodeRefDTO{
+				Id:   nr.PiholeNode.Id,
+				Name: nr.PiholeNode.Name,
+				Host: nr.PiholeNode.Host,
+			},
+			Success: nr.Success,
+			Error:   util.ErrorString(nr.Error),
+			Data:    extract(nr.Response),
+		})
+	}
+	return out
+}
+
+// -- Query params
+
+type statsTimeRangeParams struct {
+	From  *int64
+	Until *int64
+	Count *int
+}
+
+func parseStatsTimeRangeParams(q url.Values) (statsTimeRangeParams, error) {
+	var p statsTimeRangeParams
+
+	now := time.Now().UTC()
+	defaultFrom := now.Add(-24 * time.Hour).Unix()
+	defaultUntil := now.Unix()
+	p.From = &defaultFrom
+	p.Until = &defaultUntil
+
+	if r := q.Get("range"); r != "" {
+		var dur time.Duration
+		switch r {
+		case "1h":
+			dur = time.Hour
+		case "6h":
+			dur = 6 * time.Hour
+		case "24h":
+			dur = 24 * time.Hour
+		default:
+			return p, errs.Invalid(
+				fmt.Sprintf("invalid range %q", r),
+				errors.New("range must be one of: 1h, 6h, 24h"),
+			)
+		}
+		from := now.Add(-dur).Unix()
+		until := now.Unix()
+		p.From = &from
+		p.Until = &until
+	}
+
+	if v := q.Get("count"); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err != nil || n <= 0 {
+			return p, errs.Invalid("invalid count", errors.New("count must be a positive integer"))
+		}
+		p.Count = &n
+	}
+
+	return p, nil
+}

--- a/backend/internal/http/api/v1/stats_dto.go
+++ b/backend/internal/http/api/v1/stats_dto.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
@@ -242,8 +243,8 @@ func parseStatsTimeRangeParams(q url.Values) (statsTimeRangeParams, error) {
 	}
 
 	if v := q.Get("count"); v != "" {
-		var n int
-		if _, err := fmt.Sscanf(v, "%d", &n); err != nil || n <= 0 {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
 			return p, errs.Invalid("invalid count", errors.New("count must be a positive integer"))
 		}
 		p.Count = &n

--- a/backend/internal/http/api/v1/stats_handlers.go
+++ b/backend/internal/http/api/v1/stats_handlers.go
@@ -1,0 +1,74 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/http/transport"
+	"github.com/go-chi/chi"
+)
+
+func registerStats(r chi.Router, d Deps) {
+	r.Get("/stats/summary", statsGetSummary(d))
+	r.Get("/stats/history", statsGetHistory(d))
+	r.Get("/stats/top_domains", statsGetTopDomains(d))
+	r.Get("/stats/top_clients", statsGetTopClients(d))
+}
+
+func statsGetSummary(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		res, err := d.StatsService.GetSummary(r.Context())
+		if err != nil {
+			transport.WriteErr(w, err)
+			return
+		}
+		transport.WriteJSON(w, http.StatusOK, statsSummaryResponseFromDomain(res))
+	}
+}
+
+func statsGetHistory(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params, err := parseStatsTimeRangeParams(r.URL.Query())
+		if err != nil {
+			transport.WriteErr(w, err)
+			return
+		}
+		res, err := d.StatsService.GetHistory(r.Context(), params.From, params.Until)
+		if err != nil {
+			transport.WriteErr(w, err)
+			return
+		}
+		transport.WriteJSON(w, http.StatusOK, statsHistoryResponseFromDomain(res))
+	}
+}
+
+func statsGetTopDomains(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params, err := parseStatsTimeRangeParams(r.URL.Query())
+		if err != nil {
+			transport.WriteErr(w, err)
+			return
+		}
+		res, err := d.StatsService.GetTopDomains(r.Context(), params.From, params.Until, params.Count)
+		if err != nil {
+			transport.WriteErr(w, err)
+			return
+		}
+		transport.WriteJSON(w, http.StatusOK, statsTopDomainsResponseFromDomain(res))
+	}
+}
+
+func statsGetTopClients(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params, err := parseStatsTimeRangeParams(r.URL.Query())
+		if err != nil {
+			transport.WriteErr(w, err)
+			return
+		}
+		res, err := d.StatsService.GetTopClients(r.Context(), params.From, params.Until, params.Count)
+		if err != nil {
+			transport.WriteErr(w, err)
+			return
+		}
+		transport.WriteJSON(w, http.StatusOK, statsTopClientsResponseFromDomain(res))
+	}
+}

--- a/backend/internal/pihole/client.go
+++ b/backend/internal/pihole/client.go
@@ -780,7 +780,6 @@ func (c *Client) GetStatsSummary(ctx context.Context) (*domain.StatsSummary, err
 		GravitySize:    w.Gravity.DomainsBeingBlocked,
 		UniqueClients:  w.Clients.Active,
 		UniqueDomains:  w.Queries.UniqueDomains,
-		Took:           time.Duration(max(w.Took, 0) * float64(time.Second)),
 	}, nil
 }
 
@@ -815,7 +814,6 @@ func (c *Client) GetStatsHistory(ctx context.Context, from, until *int64) (*doma
 	}
 	h := &domain.StatsHistory{
 		Points: make([]domain.StatsHistoryPoint, 0, len(w.History)),
-		Took:   time.Duration(max(w.Took, 0) * float64(time.Second)),
 	}
 	for _, e := range w.History {
 		h.Points = append(h.Points, domain.StatsHistoryPoint{
@@ -842,7 +840,11 @@ func (c *Client) GetStatsTopDomains(ctx context.Context, from, until *int64, cou
 
 	// Two calls: queried (default) then blocked (?blocked=true) — Pi-hole returns
 	// only one list per request, toggled by the blocked query param.
-	queried, err := c.fetchTopDomains(ctx, base+"?"+params.Encode())
+	queriedURL := base
+	if q := params.Encode(); q != "" {
+		queriedURL += "?" + q
+	}
+	queried, err := c.fetchTopDomains(ctx, queriedURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetching queried domains: %w", err)
 	}
@@ -914,7 +916,6 @@ func (c *Client) GetStatsTopClients(ctx context.Context, from, until *int64, cou
 	}
 	out := &domain.StatsTopClients{
 		Clients: make([]domain.TopClientEntry, 0, len(w.Clients)),
-		Took:    time.Duration(max(w.Took, 0) * float64(time.Second)),
 	}
 	for _, s := range w.Clients {
 		out.Clients = append(out.Clients, domain.TopClientEntry{IP: s.IP, Name: s.Name, Count: s.Count})

--- a/backend/internal/pihole/client.go
+++ b/backend/internal/pihole/client.go
@@ -20,6 +20,14 @@ import (
 	"github.com/rs/zerolog"
 )
 
+func cloneValues(v url.Values) url.Values {
+	out := make(url.Values, len(v))
+	for k, vals := range v {
+		out[k] = append([]string(nil), vals...)
+	}
+	return out
+}
+
 func buildQueryParams(req queriesWireRequest) string {
 	params := url.Values{}
 
@@ -770,7 +778,7 @@ func (c *Client) GetStatsSummary(ctx context.Context) (*domain.StatsSummary, err
 		QueriesBlocked: w.Queries.Blocked,
 		BlockedPercent: w.Queries.PercentBlocked,
 		GravitySize:    w.Gravity.DomainsBeingBlocked,
-		UniqueClients:  w.Queries.UniqueClients,
+		UniqueClients:  w.Clients.Active,
 		UniqueDomains:  w.Queries.UniqueDomains,
 		Took:           time.Duration(max(w.Took, 0) * float64(time.Second)),
 	}, nil
@@ -779,12 +787,12 @@ func (c *Client) GetStatsSummary(ctx context.Context) (*domain.StatsSummary, err
 func (c *Client) GetStatsHistory(ctx context.Context, from, until *int64) (*domain.StatsHistory, error) {
 	params := url.Values{}
 	if from != nil {
-		params.Set("from", fmt.Sprintf("%d", *from))
+		params.Set("from", strconv.FormatInt(*from, 10))
 	}
 	if until != nil {
-		params.Set("until", fmt.Sprintf("%d", *until))
+		params.Set("until", strconv.FormatInt(*until, 10))
 	}
-	u := c.getBaseURL() + "/stats/history"
+	u := c.getBaseURL() + "/history/database"
 	if q := params.Encode(); q != "" {
 		u += "?" + q
 	}
@@ -822,18 +830,32 @@ func (c *Client) GetStatsHistory(ctx context.Context, from, until *int64) (*doma
 func (c *Client) GetStatsTopDomains(ctx context.Context, from, until *int64, count *int) (*domain.StatsTopDomains, error) {
 	params := url.Values{}
 	if from != nil {
-		params.Set("from", fmt.Sprintf("%d", *from))
+		params.Set("from", strconv.FormatInt(*from, 10))
 	}
 	if until != nil {
-		params.Set("until", fmt.Sprintf("%d", *until))
+		params.Set("until", strconv.FormatInt(*until, 10))
 	}
 	if count != nil {
-		params.Set("count", fmt.Sprintf("%d", *count))
+		params.Set("count", strconv.Itoa(*count))
 	}
-	u := c.getBaseURL() + "/stats/top_domains"
-	if q := params.Encode(); q != "" {
-		u += "?" + q
+	base := c.getBaseURL() + "/stats/database/top_domains"
+
+	// Two calls: queried (default) then blocked (?blocked=true) — Pi-hole returns
+	// only one list per request, toggled by the blocked query param.
+	queried, err := c.fetchTopDomains(ctx, base+"?"+params.Encode())
+	if err != nil {
+		return nil, fmt.Errorf("fetching queried domains: %w", err)
 	}
+	blockedParams := cloneValues(params)
+	blockedParams.Set("blocked", "true")
+	blocked, err := c.fetchTopDomains(ctx, base+"?"+blockedParams.Encode())
+	if err != nil {
+		return nil, fmt.Errorf("fetching blocked domains: %w", err)
+	}
+	return &domain.StatsTopDomains{TopQueried: queried, TopBlocked: blocked}, nil
+}
+
+func (c *Client) fetchTopDomains(ctx context.Context, u string) ([]domain.TopDomainEntry, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
@@ -851,16 +873,9 @@ func (c *Client) GetStatsTopDomains(ctx context.Context, from, until *int64, cou
 	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
 	}
-	out := &domain.StatsTopDomains{
-		TopQueried: make([]domain.TopDomainEntry, 0, len(w.TopDomains)),
-		TopBlocked: make([]domain.TopDomainEntry, 0, len(w.BlockedDomains)),
-		Took:       time.Duration(max(w.Took, 0) * float64(time.Second)),
-	}
-	for _, d := range w.TopDomains {
-		out.TopQueried = append(out.TopQueried, domain.TopDomainEntry{Domain: d.Domain, Count: d.Count})
-	}
-	for _, d := range w.BlockedDomains {
-		out.TopBlocked = append(out.TopBlocked, domain.TopDomainEntry{Domain: d.Domain, Count: d.Count})
+	out := make([]domain.TopDomainEntry, 0, len(w.Domains))
+	for _, d := range w.Domains {
+		out = append(out, domain.TopDomainEntry{Domain: d.Domain, Count: d.Count})
 	}
 	return out, nil
 }
@@ -868,15 +883,15 @@ func (c *Client) GetStatsTopDomains(ctx context.Context, from, until *int64, cou
 func (c *Client) GetStatsTopClients(ctx context.Context, from, until *int64, count *int) (*domain.StatsTopClients, error) {
 	params := url.Values{}
 	if from != nil {
-		params.Set("from", fmt.Sprintf("%d", *from))
+		params.Set("from", strconv.FormatInt(*from, 10))
 	}
 	if until != nil {
-		params.Set("until", fmt.Sprintf("%d", *until))
+		params.Set("until", strconv.FormatInt(*until, 10))
 	}
 	if count != nil {
-		params.Set("count", fmt.Sprintf("%d", *count))
+		params.Set("count", strconv.Itoa(*count))
 	}
-	u := c.getBaseURL() + "/stats/top_clients"
+	u := c.getBaseURL() + "/stats/database/top_clients"
 	if q := params.Encode(); q != "" {
 		u += "?" + q
 	}
@@ -898,10 +913,10 @@ func (c *Client) GetStatsTopClients(ctx context.Context, from, until *int64, cou
 		return nil, fmt.Errorf("decoding response: %w", err)
 	}
 	out := &domain.StatsTopClients{
-		Clients: make([]domain.TopClientEntry, 0, len(w.TopSources)),
+		Clients: make([]domain.TopClientEntry, 0, len(w.Clients)),
 		Took:    time.Duration(max(w.Took, 0) * float64(time.Second)),
 	}
-	for _, s := range w.TopSources {
+	for _, s := range w.Clients {
 		out.Clients = append(out.Clients, domain.TopClientEntry{IP: s.IP, Name: s.Name, Count: s.Count})
 	}
 	return out, nil

--- a/backend/internal/pihole/client.go
+++ b/backend/internal/pihole/client.go
@@ -745,6 +745,168 @@ func (c *Client) AuthStatus(ctx context.Context) (*domain.AuthStatus, error) {
 	}, nil
 }
 
+// Stats
+
+func (c *Client) GetStatsSummary(ctx context.Context) (*domain.StatsSummary, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.getBaseURL()+"/stats/summary", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting stats summary: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var w statsSummaryWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &domain.StatsSummary{
+		QueriesTotal:   w.Queries.Total,
+		QueriesBlocked: w.Queries.Blocked,
+		BlockedPercent: w.Queries.PercentBlocked,
+		GravitySize:    w.Gravity.DomainsBeingBlocked,
+		UniqueClients:  w.Queries.UniqueClients,
+		UniqueDomains:  w.Queries.UniqueDomains,
+		Took:           time.Duration(max(w.Took, 0) * float64(time.Second)),
+	}, nil
+}
+
+func (c *Client) GetStatsHistory(ctx context.Context, from, until *int64) (*domain.StatsHistory, error) {
+	params := url.Values{}
+	if from != nil {
+		params.Set("from", fmt.Sprintf("%d", *from))
+	}
+	if until != nil {
+		params.Set("until", fmt.Sprintf("%d", *until))
+	}
+	u := c.getBaseURL() + "/stats/history"
+	if q := params.Encode(); q != "" {
+		u += "?" + q
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting stats history: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var w statsHistoryWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	h := &domain.StatsHistory{
+		Points: make([]domain.StatsHistoryPoint, 0, len(w.History)),
+		Took:   time.Duration(max(w.Took, 0) * float64(time.Second)),
+	}
+	for _, e := range w.History {
+		h.Points = append(h.Points, domain.StatsHistoryPoint{
+			Timestamp: time.Unix(e.Timestamp, 0).UTC(),
+			Total:     e.Total,
+			Blocked:   e.Blocked,
+		})
+	}
+	return h, nil
+}
+
+func (c *Client) GetStatsTopDomains(ctx context.Context, from, until *int64, count *int) (*domain.StatsTopDomains, error) {
+	params := url.Values{}
+	if from != nil {
+		params.Set("from", fmt.Sprintf("%d", *from))
+	}
+	if until != nil {
+		params.Set("until", fmt.Sprintf("%d", *until))
+	}
+	if count != nil {
+		params.Set("count", fmt.Sprintf("%d", *count))
+	}
+	u := c.getBaseURL() + "/stats/top_domains"
+	if q := params.Encode(); q != "" {
+		u += "?" + q
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting top domains: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var w statsTopDomainsWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	out := &domain.StatsTopDomains{
+		TopQueried: make([]domain.TopDomainEntry, 0, len(w.TopDomains)),
+		TopBlocked: make([]domain.TopDomainEntry, 0, len(w.BlockedDomains)),
+		Took:       time.Duration(max(w.Took, 0) * float64(time.Second)),
+	}
+	for _, d := range w.TopDomains {
+		out.TopQueried = append(out.TopQueried, domain.TopDomainEntry{Domain: d.Domain, Count: d.Count})
+	}
+	for _, d := range w.BlockedDomains {
+		out.TopBlocked = append(out.TopBlocked, domain.TopDomainEntry{Domain: d.Domain, Count: d.Count})
+	}
+	return out, nil
+}
+
+func (c *Client) GetStatsTopClients(ctx context.Context, from, until *int64, count *int) (*domain.StatsTopClients, error) {
+	params := url.Values{}
+	if from != nil {
+		params.Set("from", fmt.Sprintf("%d", *from))
+	}
+	if until != nil {
+		params.Set("until", fmt.Sprintf("%d", *until))
+	}
+	if count != nil {
+		params.Set("count", fmt.Sprintf("%d", *count))
+	}
+	u := c.getBaseURL() + "/stats/top_clients"
+	if q := params.Encode(); q != "" {
+		u += "?" + q
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting top clients: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var w statsTopClientsWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	out := &domain.StatsTopClients{
+		Clients: make([]domain.TopClientEntry, 0, len(w.TopSources)),
+		Took:    time.Duration(max(w.Took, 0) * float64(time.Second)),
+	}
+	for _, s := range w.TopSources {
+		out.Clients = append(out.Clients, domain.TopClientEntry{IP: s.IP, Name: s.Name, Count: s.Count})
+	}
+	return out, nil
+}
+
 func (c *Client) logoutWithSID(ctx context.Context, sid string) error {
 	if sid == "" {
 		return nil

--- a/backend/internal/pihole/cluster.go
+++ b/backend/internal/pihole/cluster.go
@@ -338,6 +338,36 @@ func (c *Cluster) filterClients(nodeIDs []int64) map[int64]clientPort {
 	return targets
 }
 
+// Stats
+
+func (c *Cluster) GetStatsSummary(ctx context.Context) map[int64]*domain.NodeResult[*domain.StatsSummary] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.StatsSummary, error) {
+		return client.GetStatsSummary(nodeCtx)
+	})
+	return out
+}
+
+func (c *Cluster) GetStatsHistory(ctx context.Context, from, until *int64) map[int64]*domain.NodeResult[*domain.StatsHistory] {
+	out, _ := fanout(c, ctx, 0, 5*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.StatsHistory, error) {
+		return client.GetStatsHistory(nodeCtx, from, until)
+	})
+	return out
+}
+
+func (c *Cluster) GetStatsTopDomains(ctx context.Context, from, until *int64, count *int) map[int64]*domain.NodeResult[*domain.StatsTopDomains] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.StatsTopDomains, error) {
+		return client.GetStatsTopDomains(nodeCtx, from, until, count)
+	})
+	return out
+}
+
+func (c *Cluster) GetStatsTopClients(ctx context.Context, from, until *int64, count *int) map[int64]*domain.NodeResult[*domain.StatsTopClients] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.StatsTopClients, error) {
+		return client.GetStatsTopClients(nodeCtx, from, until, count)
+	})
+	return out
+}
+
 func (c *Cluster) AuthStatus(ctx context.Context) map[int64]*domain.NodeResult[*domain.AuthStatus] {
 	c.logger.Trace().Msg("getting auth status for cluster")
 	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.AuthStatus, error) {

--- a/backend/internal/pihole/cluster.go
+++ b/backend/internal/pihole/cluster.go
@@ -355,7 +355,7 @@ func (c *Cluster) GetStatsHistory(ctx context.Context, from, until *int64) map[i
 }
 
 func (c *Cluster) GetStatsTopDomains(ctx context.Context, from, until *int64, count *int) map[int64]*domain.NodeResult[*domain.StatsTopDomains] {
-	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.StatsTopDomains, error) {
+	out, _ := fanout(c, ctx, 0, 6*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.StatsTopDomains, error) {
 		return client.GetStatsTopDomains(nodeCtx, from, until, count)
 	})
 	return out

--- a/backend/internal/pihole/interface.go
+++ b/backend/internal/pihole/interface.go
@@ -23,6 +23,10 @@ type clientPort interface {
 	RemoveDomainRule(ctx context.Context, cmd domain.RemoveDomainRuleCommand) error
 	AuthStatus(ctx context.Context) (*domain.AuthStatus, error)
 	Logout(ctx context.Context) error
+	GetStatsSummary(ctx context.Context) (*domain.StatsSummary, error)
+	GetStatsHistory(ctx context.Context, from, until *int64) (*domain.StatsHistory, error)
+	GetStatsTopDomains(ctx context.Context, from, until *int64, count *int) (*domain.StatsTopDomains, error)
+	GetStatsTopClients(ctx context.Context, from, until *int64, count *int) (*domain.StatsTopClients, error)
 }
 
 type cursorManagerPort[T any] interface {

--- a/backend/internal/pihole/wire.go
+++ b/backend/internal/pihole/wire.go
@@ -139,6 +139,55 @@ type domainWireInfo struct {
 	DateModified int64   `json:"date_modified"`
 }
 
+// Stats
+
+type statsSummaryWireResponse struct {
+	Queries struct {
+		Total          int64   `json:"total"`
+		Blocked        int64   `json:"blocked"`
+		PercentBlocked float64 `json:"percent_blocked"`
+		UniqueClients  int64   `json:"unique_clients"`
+		UniqueDomains  int64   `json:"unique_domains"`
+	} `json:"queries"`
+	Gravity struct {
+		DomainsBeingBlocked int64 `json:"domains_being_blocked"`
+	} `json:"gravity"`
+	Took float64 `json:"took"`
+}
+
+type statsHistoryEntryWire struct {
+	Timestamp int64 `json:"timestamp"`
+	Total     int64 `json:"total"`
+	Blocked   int64 `json:"blocked"`
+}
+
+type statsHistoryWireResponse struct {
+	History []statsHistoryEntryWire `json:"history"`
+	Took    float64                 `json:"took"`
+}
+
+type topDomainEntryWire struct {
+	Domain string `json:"domain"`
+	Count  int64  `json:"count"`
+}
+
+type statsTopDomainsWireResponse struct {
+	TopDomains    []topDomainEntryWire `json:"top_domains"`
+	BlockedDomains []topDomainEntryWire `json:"blocked_domains"`
+	Took           float64              `json:"took"`
+}
+
+type topClientEntryWire struct {
+	IP    string `json:"ip"`
+	Name  string `json:"name"`
+	Count int64  `json:"count"`
+}
+
+type statsTopClientsWireResponse struct {
+	TopSources []topClientEntryWire `json:"top_sources"`
+	Took       float64              `json:"took"`
+}
+
 type addDomainsWireResponse struct {
 	Domains   []domainWireInfo `json:"domains"`
 	Processed *struct {

--- a/backend/internal/pihole/wire.go
+++ b/backend/internal/pihole/wire.go
@@ -146,9 +146,12 @@ type statsSummaryWireResponse struct {
 		Total          int64   `json:"total"`
 		Blocked        int64   `json:"blocked"`
 		PercentBlocked float64 `json:"percent_blocked"`
-		UniqueClients  int64   `json:"unique_clients"`
 		UniqueDomains  int64   `json:"unique_domains"`
 	} `json:"queries"`
+	Clients struct {
+		Active int64 `json:"active"`
+		Total  int64 `json:"total"`
+	} `json:"clients"`
 	Gravity struct {
 		DomainsBeingBlocked int64 `json:"domains_being_blocked"`
 	} `json:"gravity"`
@@ -172,9 +175,8 @@ type topDomainEntryWire struct {
 }
 
 type statsTopDomainsWireResponse struct {
-	TopDomains    []topDomainEntryWire `json:"top_domains"`
-	BlockedDomains []topDomainEntryWire `json:"blocked_domains"`
-	Took           float64              `json:"took"`
+	Domains []topDomainEntryWire `json:"domains"`
+	Took    float64              `json:"took"`
 }
 
 type topClientEntryWire struct {
@@ -184,8 +186,8 @@ type topClientEntryWire struct {
 }
 
 type statsTopClientsWireResponse struct {
-	TopSources []topClientEntryWire `json:"top_sources"`
-	Took       float64              `json:"took"`
+	Clients []topClientEntryWire `json:"clients"`
+	Took    float64              `json:"took"`
 }
 
 type addDomainsWireResponse struct {

--- a/backend/internal/service/stats/interface.go
+++ b/backend/internal/service/stats/interface.go
@@ -1,0 +1,14 @@
+package statssvc
+
+import (
+	"context"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+)
+
+type cluster interface {
+	GetStatsSummary(ctx context.Context) map[int64]*domain.NodeResult[*domain.StatsSummary]
+	GetStatsHistory(ctx context.Context, from, until *int64) map[int64]*domain.NodeResult[*domain.StatsHistory]
+	GetStatsTopDomains(ctx context.Context, from, until *int64, count *int) map[int64]*domain.NodeResult[*domain.StatsTopDomains]
+	GetStatsTopClients(ctx context.Context, from, until *int64, count *int) map[int64]*domain.NodeResult[*domain.StatsTopClients]
+}

--- a/backend/internal/service/stats/service.go
+++ b/backend/internal/service/stats/service.go
@@ -94,6 +94,9 @@ func (s *Service) GetTopDomains(ctx context.Context, from, until *int64, count *
 		limit = *count
 	}
 
+	// Note: each node returns its own top-N list, so a domain ranked outside the top N
+	// on every individual node but top-N cluster-wide can be missed. This is an accepted
+	// approximation; the alternative would require fetching all domains from every node.
 	return &domain.ClusterStatsTopDomains{
 		ClusterTopQueried: sortedDomains(queriedMap, limit),
 		ClusterTopBlocked: sortedDomains(blockedMap, limit),

--- a/backend/internal/service/stats/service.go
+++ b/backend/internal/service/stats/service.go
@@ -1,0 +1,145 @@
+package statssvc
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/rs/zerolog"
+)
+
+type Service struct {
+	cluster cluster
+	logger  zerolog.Logger
+}
+
+func NewService(cluster cluster, logger zerolog.Logger) *Service {
+	return &Service{cluster: cluster, logger: logger}
+}
+
+func (s *Service) GetSummary(ctx context.Context) (*domain.ClusterStatsSummary, error) {
+	nodes := s.cluster.GetStatsSummary(ctx)
+	var agg domain.StatsSummary
+	for _, nr := range nodes {
+		if !nr.Success || nr.Response == nil {
+			continue
+		}
+		r := nr.Response
+		agg.QueriesTotal += r.QueriesTotal
+		agg.QueriesBlocked += r.QueriesBlocked
+		if r.GravitySize > agg.GravitySize {
+			agg.GravitySize = r.GravitySize
+		}
+		agg.UniqueClients += r.UniqueClients
+		agg.UniqueDomains += r.UniqueDomains
+	}
+	if agg.QueriesTotal > 0 {
+		agg.BlockedPercent = float64(agg.QueriesBlocked) / float64(agg.QueriesTotal) * 100
+	}
+	return &domain.ClusterStatsSummary{Cluster: agg, Nodes: nodes}, nil
+}
+
+func (s *Service) GetHistory(ctx context.Context, from, until *int64) (*domain.ClusterStatsHistory, error) {
+	nodes := s.cluster.GetStatsHistory(ctx, from, until)
+
+	// Aggregate by aligning on timestamp buckets
+	type bucket struct{ total, blocked int64 }
+	buckets := make(map[int64]*bucket)
+	for _, nr := range nodes {
+		if !nr.Success || nr.Response == nil {
+			continue
+		}
+		for _, p := range nr.Response.Points {
+			ts := p.Timestamp.Unix()
+			if buckets[ts] == nil {
+				buckets[ts] = &bucket{}
+			}
+			buckets[ts].total += p.Total
+			buckets[ts].blocked += p.Blocked
+		}
+	}
+
+	points := make([]domain.StatsHistoryPoint, 0, len(buckets))
+	for ts, b := range buckets {
+		points = append(points, domain.StatsHistoryPoint{
+			Timestamp: time.Unix(ts, 0).UTC(),
+			Total:     b.total,
+			Blocked:   b.blocked,
+		})
+	}
+	sort.Slice(points, func(i, j int) bool { return points[i].Timestamp.Before(points[j].Timestamp) })
+	return &domain.ClusterStatsHistory{ClusterPoints: points, Nodes: nodes}, nil
+}
+
+func (s *Service) GetTopDomains(ctx context.Context, from, until *int64, count *int) (*domain.ClusterStatsTopDomains, error) {
+	nodes := s.cluster.GetStatsTopDomains(ctx, from, until, count)
+
+	queriedMap := make(map[string]int64)
+	blockedMap := make(map[string]int64)
+	for _, nr := range nodes {
+		if !nr.Success || nr.Response == nil {
+			continue
+		}
+		for _, d := range nr.Response.TopQueried {
+			queriedMap[d.Domain] += d.Count
+		}
+		for _, d := range nr.Response.TopBlocked {
+			blockedMap[d.Domain] += d.Count
+		}
+	}
+
+	limit := 10
+	if count != nil && *count > 0 {
+		limit = *count
+	}
+
+	return &domain.ClusterStatsTopDomains{
+		ClusterTopQueried: sortedDomains(queriedMap, limit),
+		ClusterTopBlocked: sortedDomains(blockedMap, limit),
+		Nodes:             nodes,
+	}, nil
+}
+
+func (s *Service) GetTopClients(ctx context.Context, from, until *int64, count *int) (*domain.ClusterStatsTopClients, error) {
+	nodes := s.cluster.GetStatsTopClients(ctx, from, until, count)
+
+	type clientKey struct{ ip, name string }
+	clientMap := make(map[clientKey]int64)
+	for _, nr := range nodes {
+		if !nr.Success || nr.Response == nil {
+			continue
+		}
+		for _, c := range nr.Response.Clients {
+			clientMap[clientKey{ip: c.IP, name: c.Name}] += c.Count
+		}
+	}
+
+	limit := 10
+	if count != nil && *count > 0 {
+		limit = *count
+	}
+
+	entries := make([]domain.TopClientEntry, 0, len(clientMap))
+	for k, cnt := range clientMap {
+		entries = append(entries, domain.TopClientEntry{IP: k.ip, Name: k.name, Count: cnt})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Count > entries[j].Count })
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+
+	return &domain.ClusterStatsTopClients{ClusterClients: entries, Nodes: nodes}, nil
+}
+
+func sortedDomains(m map[string]int64, limit int) []domain.TopDomainEntry {
+	out := make([]domain.TopDomainEntry, 0, len(m))
+	for d, c := range m {
+		out = append(out, domain.TopDomainEntry{Domain: d, Count: c})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Count > out[j].Count })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
 		"lucide-react": "^0.515.0",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
-		"react-router": "^7.15.0"
+		"react-router": "^7.15.0",
+		"recharts": "^2.15.3"
 	}
 }

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -16,6 +16,7 @@ import { Login } from '@/pages/Login';
 import { UnhandledRoute } from './routes/UnhandledRoute';
 import { Account } from '@/pages/Account/Account';
 import { Audit } from '@/pages/Audit';
+import { Stats } from '@/pages/Stats';
 
 export const router = createBrowserRouter([
 	{
@@ -48,6 +49,11 @@ export const router = createBrowserRouter([
 						path: '/recent-blocks',
 						Component: RecentBlocks,
 						handle: { layoutOptions: { pageTitle: 'Recent Blocks' } },
+					},
+					{
+						path: '/stats',
+						Component: Stats,
+						handle: { layoutOptions: { pageTitle: 'Stats' } },
 					},
 					{
 						path: '/audit',

--- a/frontend/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { NavLink } from 'react-router';
 import {
+	BarChart2,
 	ChevronRight,
 	ChevronLeft,
 	Clock,
@@ -26,6 +27,7 @@ const links = [
 	{ to: '/recent-blocks', label: 'Recent Blocks', icon: ShieldAlert },
 	{ to: '/query', label: 'Query Log', icon: FileText },
 	{ to: '/domains', label: 'Domains', icon: List },
+	{ to: '/stats', label: 'Stats', icon: BarChart2 },
 	{ to: '/audit', label: 'Audit Log', icon: Clock },
 	{ to: '/settings', label: 'Settings', icon: SettingsIcon },
 ];

--- a/frontend/src/lib/api/stats.ts
+++ b/frontend/src/lib/api/stats.ts
@@ -1,0 +1,34 @@
+import { apiV1Fetch } from './client';
+import type {
+	StatsSummaryResponse,
+	StatsHistoryResponse,
+	StatsTopDomainsResponse,
+	StatsTopClientsResponse,
+	StatsRange,
+} from '@/types/stats';
+
+export async function getStatsSummary(): Promise<StatsSummaryResponse> {
+	return apiV1Fetch<StatsSummaryResponse>('/stats/summary');
+}
+
+export async function getStatsHistory(range: StatsRange = '24h'): Promise<StatsHistoryResponse> {
+	return apiV1Fetch<StatsHistoryResponse>(`/stats/history?range=${range}`);
+}
+
+export async function getStatsTopDomains(
+	range: StatsRange = '24h',
+	count = 10,
+): Promise<StatsTopDomainsResponse> {
+	return apiV1Fetch<StatsTopDomainsResponse>(
+		`/stats/top_domains?range=${range}&count=${count}`,
+	);
+}
+
+export async function getStatsTopClients(
+	range: StatsRange = '24h',
+	count = 10,
+): Promise<StatsTopClientsResponse> {
+	return apiV1Fetch<StatsTopClientsResponse>(
+		`/stats/top_clients?range=${range}&count=${count}`,
+	);
+}

--- a/frontend/src/pages/Home.module.scss
+++ b/frontend/src/pages/Home.module.scss
@@ -146,6 +146,30 @@
 	color: var(--accent-danger);
 }
 
+.sectionTitleRow {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	margin-bottom: 0.75rem;
+
+	.sectionTitle {
+		margin-bottom: 0;
+	}
+}
+
+.statsLink {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.15rem;
+	font-size: 0.8rem;
+	color: var(--link-color);
+	text-decoration: none;
+
+	&:hover {
+		text-decoration: underline;
+	}
+}
+
 .empty {
 	color: var(--text-secondary);
 	font-size: 0.9rem;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,13 +6,8 @@ import { getBlockingDisplayState } from '@/utils/blockingStatus';
 import { PiholeStatusLight } from '@/components/StatusLight/PiholeStatusLight';
 import { getStatsSummary } from '@/lib/api/stats';
 import type { StatsSummaryResponse } from '@/types/stats';
+import { formatCount } from '@/utils/formatters';
 import styles from './Home.module.scss';
-
-function formatCount(n: number): string {
-	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-	return String(n);
-}
 
 export function Home() {
 	const { blocking, nodes, healthFresh, healthSummary } = useClusterOverview();

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,12 +1,33 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router';
+import { ChevronRight } from 'lucide-react';
 import { useClusterOverview } from '@/hooks/useClusterOverview';
 import { getBlockingDisplayState } from '@/utils/blockingStatus';
 import { PiholeStatusLight } from '@/components/StatusLight/PiholeStatusLight';
+import { getStatsSummary } from '@/lib/api/stats';
+import type { StatsSummaryResponse } from '@/types/stats';
 import styles from './Home.module.scss';
+
+function formatCount(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+	return String(n);
+}
 
 export function Home() {
 	const { blocking, nodes, healthFresh, healthSummary } = useClusterOverview();
 	const blockingDisplay = getBlockingDisplayState(blocking?.summary);
 	const { icon: StatusIcon, colorVar, label: blockingLabel } = blockingDisplay;
+
+	const [statsSummary, setStatsSummary] = useState<StatsSummaryResponse | null>(null);
+
+	useEffect(() => {
+		getStatsSummary()
+			.then(setStatsSummary)
+			.catch(() => {});
+	}, []);
+
+	const cluster = statsSummary?.cluster;
 
 	return (
 		<div className={styles.page}>
@@ -41,6 +62,37 @@ export function Home() {
 							)}
 						</div>
 						<div className={styles.cardSub}>Nodes online</div>
+					</div>
+				</div>
+			</section>
+
+			<section className={styles.section} aria-labelledby='stats-heading'>
+				<div className={styles.sectionTitleRow}>
+					<h2 id='stats-heading' className={styles.sectionTitle}>
+						Stats
+					</h2>
+					<Link to='/stats' className={styles.statsLink}>
+						View all <ChevronRight size={14} />
+					</Link>
+				</div>
+				<div className={styles.summaryCards}>
+					<div className={styles.card}>
+						<div className={styles.statValue}>
+							{cluster != null ? formatCount(cluster.queriesTotal) : '—'}
+						</div>
+						<div className={styles.cardSub}>Total Queries</div>
+					</div>
+					<div className={styles.card}>
+						<div className={styles.statValue}>
+							{cluster != null ? `${cluster.blockedPercent.toFixed(1)}%` : '—'}
+						</div>
+						<div className={styles.cardSub}>Blocked</div>
+					</div>
+					<div className={styles.card}>
+						<div className={styles.statValue}>
+							{cluster != null ? formatCount(cluster.gravitySize) : '—'}
+						</div>
+						<div className={styles.cardSub}>Gravity Size</div>
 					</div>
 				</div>
 			</section>

--- a/frontend/src/pages/Stats.module.scss
+++ b/frontend/src/pages/Stats.module.scss
@@ -1,0 +1,336 @@
+@use '@/styles/mixins' as *;
+@use '@/styles/variables' as *;
+
+.page {
+	padding: 1.25rem;
+	max-width: 72rem;
+	margin-inline: auto;
+}
+
+.pageHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 1.5rem;
+}
+
+.pageTitle {
+	font-size: 1.25rem;
+	font-weight: 700;
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.refreshBtn {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.4rem 0.9rem;
+	font-size: 0.85rem;
+	font-weight: 500;
+	color: var(--btn-surface-text);
+	background: var(--btn-surface-bg);
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: var(--btn-surface-bg-hover);
+	}
+
+	&:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+}
+
+@keyframes spin {
+	from { transform: rotate(0deg); }
+	to   { transform: rotate(360deg); }
+}
+
+.spinning {
+	animation: spin 0.8s linear infinite;
+}
+
+.errorBanner {
+	background: var(--error-bg);
+	color: var(--error-text);
+	padding: 0.6rem 1rem;
+	border-radius: var(--border-radius);
+	font-size: 0.875rem;
+	margin-bottom: 1rem;
+}
+
+.partialWarning {
+	background: color-mix(in oklab, var(--accent-warn) 15%, var(--bg-card));
+	border: 1px solid var(--accent-warn);
+	color: var(--text-primary);
+	padding: 0.5rem 1rem;
+	border-radius: var(--border-radius);
+	font-size: 0.85rem;
+	margin-bottom: 1rem;
+}
+
+.section {
+	margin-bottom: 1.75rem;
+}
+
+.sectionTitle {
+	font-size: 0.8rem;
+	font-weight: 600;
+	color: var(--text-secondary);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	margin: 0 0 0.75rem 0;
+}
+
+// Summary cards
+
+.summaryCards {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+	gap: 0.75rem;
+}
+
+.card {
+	background: var(--bg-card);
+	border: 1px solid var(--border-card);
+	border-radius: var(--card-radius);
+	box-shadow: var(--card-shadow);
+	padding: 1.1rem 1.25rem;
+}
+
+.statValue {
+	font-size: 1.85rem;
+	font-weight: 700;
+	color: var(--text-primary);
+	line-height: 1.1;
+}
+
+.cardSub {
+	font-size: 0.78rem;
+	color: var(--text-secondary);
+	margin-top: 0.3rem;
+}
+
+// Range bar
+
+.rangeBar {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	margin-bottom: 1rem;
+}
+
+.rangeLabel {
+	font-size: 0.85rem;
+	color: var(--text-secondary);
+}
+
+.rangeButtons {
+	display: flex;
+	gap: 0.25rem;
+}
+
+.rangeBtn {
+	padding: 0.3rem 0.75rem;
+	font-size: 0.82rem;
+	font-weight: 500;
+	color: var(--text-primary);
+	background: var(--bg-card);
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast), border-color var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: var(--bg-muted);
+	}
+
+	&:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+}
+
+.rangeBtnActive {
+	background: var(--accent-primary);
+	border-color: var(--accent-primary);
+	color: var(--accent-text);
+
+	&:hover:not(:disabled) {
+		background: var(--accent-primary-hover);
+	}
+}
+
+// Chart
+
+.chartCard {
+	background: var(--bg-card);
+	border: 1px solid var(--border-card);
+	border-radius: var(--card-radius);
+	box-shadow: var(--card-shadow);
+	padding: 1.25rem 1rem 1rem;
+}
+
+.chartPlaceholder {
+	height: 260px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text-secondary);
+	font-size: 0.9rem;
+}
+
+// Tables
+
+.tablesGrid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 1.25rem;
+	margin-bottom: 1.75rem;
+}
+
+.tableCard {
+	background: var(--bg-card);
+	border: 1px solid var(--border-card);
+	border-radius: var(--card-radius);
+	box-shadow: var(--card-shadow);
+	padding: 1rem 1.25rem;
+}
+
+.tableSubheading {
+	font-size: 0.8rem;
+	font-weight: 600;
+	color: var(--text-secondary);
+	margin: 0 0 0.5rem;
+}
+
+.table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.85rem;
+
+	th {
+		text-align: left;
+		color: var(--text-secondary);
+		font-weight: 500;
+		padding: 0.25rem 0.5rem;
+		border-bottom: 1px solid var(--border-primary);
+	}
+
+	td {
+		padding: 0.35rem 0.5rem;
+		color: var(--text-primary);
+		border-bottom: 1px solid var(--bg-table-stripe);
+	}
+
+	tr:last-child td {
+		border-bottom: none;
+	}
+
+	tr:hover td {
+		background: var(--bg-table-stripe);
+	}
+}
+
+.countCol {
+	text-align: right;
+	white-space: nowrap;
+	font-variant-numeric: tabular-nums;
+}
+
+.domainCell {
+	font-family: monospace;
+	font-size: 0.82rem;
+	word-break: break-all;
+}
+
+.clientName {
+	display: block;
+	font-weight: 500;
+}
+
+.clientIp {
+	display: block;
+	font-size: 0.78rem;
+	color: var(--text-secondary);
+	font-family: monospace;
+}
+
+.tableEmpty {
+	text-align: center;
+	color: var(--text-secondary);
+	padding: 1rem 0;
+}
+
+// Node breakdown
+
+.nodeGrid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+	gap: 0.75rem;
+}
+
+.nodeCard {
+	background: var(--bg-card);
+	border: 1px solid var(--border-card);
+	border-radius: var(--card-radius);
+	box-shadow: var(--card-shadow);
+	padding: 1rem 1.25rem;
+
+	&[data-success='false'] {
+		border-left: 3px solid var(--accent-danger);
+	}
+}
+
+.nodeName {
+	font-weight: 600;
+	font-size: 0.95rem;
+	color: var(--text-primary);
+	margin-bottom: 0.6rem;
+}
+
+.nodeError {
+	font-size: 0.82rem;
+	color: var(--accent-danger);
+}
+
+.nodeStats {
+	margin: 0;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 0.3rem 0.75rem;
+}
+
+.nodeStat {
+	display: flex;
+	flex-direction: column;
+	font-size: 0.82rem;
+
+	dt {
+		color: var(--text-secondary);
+	}
+
+	dd {
+		margin: 0;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+}
+
+@include respond-max($breakpoint-md) {
+	.page {
+		padding: 1rem;
+	}
+
+	.tablesGrid {
+		grid-template-columns: 1fr;
+	}
+
+	.summaryCards {
+		grid-template-columns: 1fr 1fr;
+	}
+}

--- a/frontend/src/pages/Stats.module.scss
+++ b/frontend/src/pages/Stats.module.scss
@@ -209,10 +209,8 @@
 }
 
 .tableSubheadingSpaced {
-	font-size: 0.8rem;
-	font-weight: 600;
-	color: var(--text-secondary);
-	margin: 1rem 0 0.5rem;
+	composes: tableSubheading;
+	margin-top: 1rem;
 }
 
 .table {

--- a/frontend/src/pages/Stats.module.scss
+++ b/frontend/src/pages/Stats.module.scss
@@ -83,7 +83,14 @@
 	color: var(--text-secondary);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
-	margin: 0 0 0.75rem 0;
+	margin: 0 0 0.25rem 0;
+}
+
+.sectionNote {
+	font-size: 0.75rem;
+	color: var(--text-secondary);
+	margin: 0 0 0.75rem;
+	font-style: italic;
 }
 
 // Summary cards

--- a/frontend/src/pages/Stats.module.scss
+++ b/frontend/src/pages/Stats.module.scss
@@ -208,6 +208,13 @@
 	margin: 0 0 0.5rem;
 }
 
+.tableSubheadingSpaced {
+	font-size: 0.8rem;
+	font-weight: 600;
+	color: var(--text-secondary);
+	margin: 1rem 0 0.5rem;
+}
+
 .table {
 	width: 100%;
 	border-collapse: collapse;

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -24,6 +24,7 @@ import type {
 	StatsTopClientsResponse,
 	StatsRange,
 } from '@/types/stats';
+import { formatCount } from '@/utils/formatters';
 import styles from './Stats.module.scss';
 
 const RANGES: { label: string; value: StatsRange }[] = [
@@ -32,19 +33,10 @@ const RANGES: { label: string; value: StatsRange }[] = [
 	{ label: '24h', value: '24h' },
 ];
 
-function formatCount(n: number): string {
-	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-	return String(n);
-}
-
 function formatTimestamp(ts: string, range: StatsRange): string {
 	const d = new Date(ts);
-	if (range === '1h') {
-		return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-	}
-	if (range === '6h') {
-		return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+	if (range === '24h') {
+		return d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
 	}
 	return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
@@ -114,8 +106,6 @@ export function Stats() {
 		setError(null);
 		try {
 			await loadAll(range);
-		} catch (e) {
-			setError(e instanceof Error ? e.message : 'Failed to load stats');
 		} finally {
 			setRangeLoading(false);
 		}
@@ -185,7 +175,10 @@ export function Stats() {
 						</div>
 						<div className={styles.cardSub}>Gravity Size</div>
 					</div>
-					<div className={styles.card}>
+					<div
+						className={styles.card}
+						title='Sum across all nodes — clients seen by multiple nodes may be counted more than once'
+					>
 						<div className={styles.statValue}>
 							{loading ? '—' : formatCount(cluster?.uniqueClients ?? 0)}
 						</div>
@@ -313,7 +306,7 @@ export function Stats() {
 							</tbody>
 						</table>
 
-						<p className={styles.tableSubheading} style={{ marginTop: '1rem' }}>
+						<p className={styles.tableSubheadingSpaced}>
 							Most blocked
 						</p>
 						<table className={styles.table}>

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,0 +1,435 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+	LineChart,
+	Line,
+	XAxis,
+	YAxis,
+	CartesianGrid,
+	Tooltip,
+	Legend,
+	ResponsiveContainer,
+} from 'recharts';
+import { RefreshCw } from 'lucide-react';
+import classNames from 'classnames';
+import {
+	getStatsSummary,
+	getStatsHistory,
+	getStatsTopDomains,
+	getStatsTopClients,
+} from '@/lib/api/stats';
+import type {
+	StatsSummaryResponse,
+	StatsHistoryResponse,
+	StatsTopDomainsResponse,
+	StatsTopClientsResponse,
+	StatsRange,
+} from '@/types/stats';
+import styles from './Stats.module.scss';
+
+const RANGES: { label: string; value: StatsRange }[] = [
+	{ label: '1h', value: '1h' },
+	{ label: '6h', value: '6h' },
+	{ label: '24h', value: '24h' },
+];
+
+function formatCount(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+	return String(n);
+}
+
+function formatTimestamp(ts: string, range: StatsRange): string {
+	const d = new Date(ts);
+	if (range === '1h') {
+		return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+	}
+	if (range === '6h') {
+		return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+	}
+	return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+export function Stats() {
+	const [range, setRange] = useState<StatsRange>('24h');
+	const [summary, setSummary] = useState<StatsSummaryResponse | null>(null);
+	const [history, setHistory] = useState<StatsHistoryResponse | null>(null);
+	const [topDomains, setTopDomains] = useState<StatsTopDomainsResponse | null>(null);
+	const [topClients, setTopClients] = useState<StatsTopClientsResponse | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [rangeLoading, setRangeLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const loadedRef = useRef(false);
+
+	const loadSummary = useCallback(async () => {
+		const res = await getStatsSummary();
+		setSummary(res);
+	}, []);
+
+	const loadRangeData = useCallback(async (r: StatsRange) => {
+		const [h, td, tc] = await Promise.all([
+			getStatsHistory(r),
+			getStatsTopDomains(r),
+			getStatsTopClients(r),
+		]);
+		setHistory(h);
+		setTopDomains(td);
+		setTopClients(tc);
+	}, []);
+
+	const loadAll = useCallback(
+		async (r: StatsRange) => {
+			setError(null);
+			try {
+				await Promise.all([loadSummary(), loadRangeData(r)]);
+			} catch (e) {
+				setError(e instanceof Error ? e.message : 'Failed to load stats');
+			}
+		},
+		[loadSummary, loadRangeData],
+	);
+
+	useEffect(() => {
+		if (loadedRef.current) return;
+		loadedRef.current = true;
+		setLoading(true);
+		loadAll(range).finally(() => setLoading(false));
+	}, [loadAll, range]);
+
+	const handleRangeChange = async (r: StatsRange) => {
+		if (r === range) return;
+		setRange(r);
+		setRangeLoading(true);
+		setError(null);
+		try {
+			await loadRangeData(r);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : 'Failed to load stats');
+		} finally {
+			setRangeLoading(false);
+		}
+	};
+
+	const handleRefresh = async () => {
+		setRangeLoading(true);
+		setError(null);
+		try {
+			await loadAll(range);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : 'Failed to load stats');
+		} finally {
+			setRangeLoading(false);
+		}
+	};
+
+	const cluster = summary?.cluster;
+	const chartData =
+		history?.cluster.map((p) => ({
+			time: formatTimestamp(p.timestamp, range),
+			allowed: p.total - p.blocked,
+			blocked: p.blocked,
+		})) ?? [];
+
+	const partialNodes = [
+		...(summary?.nodes ?? []),
+		...(history?.nodes ?? []),
+		...(topDomains?.nodes ?? []),
+		...(topClients?.nodes ?? []),
+	].filter((n) => !n.success);
+	const uniqueFailedNodes = [...new Map(partialNodes.map((n) => [n.node.id, n])).values()];
+
+	return (
+		<div className={styles.page}>
+			<div className={styles.pageHeader}>
+				<h1 className={styles.pageTitle}>Stats &amp; Analytics</h1>
+				<button
+					className={styles.refreshBtn}
+					onClick={handleRefresh}
+					disabled={rangeLoading}
+					aria-label='Refresh stats'
+				>
+					<RefreshCw size={16} className={classNames({ [styles.spinning]: rangeLoading })} />
+					Refresh
+				</button>
+			</div>
+
+			{error && <div className={styles.errorBanner}>{error}</div>}
+
+			{uniqueFailedNodes.length > 0 && (
+				<div className={styles.partialWarning}>
+					Partial data — nodes unavailable:{' '}
+					{uniqueFailedNodes.map((n) => n.node.name).join(', ')}
+				</div>
+			)}
+
+			{/* Summary cards */}
+			<section className={styles.section} aria-labelledby='summary-heading'>
+				<h2 id='summary-heading' className={styles.sectionTitle}>
+					Cluster Summary
+				</h2>
+				<div className={styles.summaryCards}>
+					<div className={styles.card}>
+						<div className={styles.statValue}>
+							{loading ? '—' : formatCount(cluster?.queriesTotal ?? 0)}
+						</div>
+						<div className={styles.cardSub}>Total Queries</div>
+					</div>
+					<div className={styles.card}>
+						<div className={styles.statValue}>
+							{loading ? '—' : `${(cluster?.blockedPercent ?? 0).toFixed(1)}%`}
+						</div>
+						<div className={styles.cardSub}>Blocked</div>
+					</div>
+					<div className={styles.card}>
+						<div className={styles.statValue}>
+							{loading ? '—' : formatCount(cluster?.gravitySize ?? 0)}
+						</div>
+						<div className={styles.cardSub}>Gravity Size</div>
+					</div>
+					<div className={styles.card}>
+						<div className={styles.statValue}>
+							{loading ? '—' : formatCount(cluster?.uniqueClients ?? 0)}
+						</div>
+						<div className={styles.cardSub}>Unique Clients</div>
+					</div>
+				</div>
+			</section>
+
+			{/* Range controls */}
+			<div className={styles.rangeBar}>
+				<span className={styles.rangeLabel}>Range:</span>
+				<div className={styles.rangeButtons} role='group' aria-label='Time range'>
+					{RANGES.map(({ label, value }) => (
+						<button
+							key={value}
+							className={classNames(styles.rangeBtn, { [styles.rangeBtnActive]: range === value })}
+							onClick={() => handleRangeChange(value)}
+							disabled={rangeLoading}
+							aria-pressed={range === value}
+						>
+							{label}
+						</button>
+					))}
+				</div>
+			</div>
+
+			{/* History chart */}
+			<section className={styles.section} aria-labelledby='history-heading'>
+				<h2 id='history-heading' className={styles.sectionTitle}>
+					Query History
+				</h2>
+				<div className={styles.chartCard}>
+					{rangeLoading || loading ? (
+						<div className={styles.chartPlaceholder}>Loading…</div>
+					) : chartData.length === 0 ? (
+						<div className={styles.chartPlaceholder}>No data</div>
+					) : (
+						<ResponsiveContainer width='100%' height={260}>
+							<LineChart data={chartData} margin={{ top: 4, right: 16, bottom: 0, left: 0 }}>
+								<CartesianGrid strokeDasharray='3 3' stroke='var(--border-primary)' />
+								<XAxis
+									dataKey='time'
+									tick={{ fontSize: 11, fill: 'var(--text-secondary)' }}
+									interval='preserveStartEnd'
+								/>
+								<YAxis
+									tick={{ fontSize: 11, fill: 'var(--text-secondary)' }}
+									tickFormatter={formatCount}
+									width={48}
+								/>
+								<Tooltip
+									contentStyle={{
+										background: 'var(--bg-card)',
+										border: '1px solid var(--border-card)',
+										borderRadius: 'var(--border-radius)',
+										fontSize: 12,
+									}}
+									formatter={(value: number, name: string) => [
+										formatCount(value),
+										name === 'blocked' ? 'Blocked' : 'Allowed',
+									]}
+								/>
+								<Legend
+									wrapperStyle={{ fontSize: 12, paddingTop: 8 }}
+									formatter={(value) => (value === 'blocked' ? 'Blocked' : 'Allowed')}
+								/>
+								<Line
+									type='monotone'
+									dataKey='allowed'
+									stroke='var(--accent-success)'
+									strokeWidth={2}
+									dot={false}
+									activeDot={{ r: 4 }}
+								/>
+								<Line
+									type='monotone'
+									dataKey='blocked'
+									stroke='var(--accent-danger)'
+									strokeWidth={2}
+									dot={false}
+									activeDot={{ r: 4 }}
+								/>
+							</LineChart>
+						</ResponsiveContainer>
+					)}
+				</div>
+			</section>
+
+			{/* Top tables */}
+			<div className={styles.tablesGrid}>
+				<section className={styles.section} aria-labelledby='top-domains-heading'>
+					<h2 id='top-domains-heading' className={styles.sectionTitle}>
+						Top Domains
+					</h2>
+					<div className={styles.tableCard}>
+						<p className={styles.tableSubheading}>Most queried</p>
+						<table className={styles.table}>
+							<thead>
+								<tr>
+									<th>Domain</th>
+									<th className={styles.countCol}>Queries</th>
+								</tr>
+							</thead>
+							<tbody>
+								{rangeLoading || loading ? (
+									<tr>
+										<td colSpan={2} className={styles.tableEmpty}>
+											Loading…
+										</td>
+									</tr>
+								) : (topDomains?.clusterTopQueried ?? []).length === 0 ? (
+									<tr>
+										<td colSpan={2} className={styles.tableEmpty}>
+											No data
+										</td>
+									</tr>
+								) : (
+									(topDomains?.clusterTopQueried ?? []).map((d) => (
+										<tr key={d.domain}>
+											<td className={styles.domainCell}>{d.domain}</td>
+											<td className={styles.countCol}>{formatCount(d.count)}</td>
+										</tr>
+									))
+								)}
+							</tbody>
+						</table>
+
+						<p className={styles.tableSubheading} style={{ marginTop: '1rem' }}>
+							Most blocked
+						</p>
+						<table className={styles.table}>
+							<thead>
+								<tr>
+									<th>Domain</th>
+									<th className={styles.countCol}>Blocked</th>
+								</tr>
+							</thead>
+							<tbody>
+								{rangeLoading || loading ? (
+									<tr>
+										<td colSpan={2} className={styles.tableEmpty}>
+											Loading…
+										</td>
+									</tr>
+								) : (topDomains?.clusterTopBlocked ?? []).length === 0 ? (
+									<tr>
+										<td colSpan={2} className={styles.tableEmpty}>
+											No data
+										</td>
+									</tr>
+								) : (
+									(topDomains?.clusterTopBlocked ?? []).map((d) => (
+										<tr key={d.domain}>
+											<td className={styles.domainCell}>{d.domain}</td>
+											<td className={styles.countCol}>{formatCount(d.count)}</td>
+										</tr>
+									))
+								)}
+							</tbody>
+						</table>
+					</div>
+				</section>
+
+				<section className={styles.section} aria-labelledby='top-clients-heading'>
+					<h2 id='top-clients-heading' className={styles.sectionTitle}>
+						Top Clients
+					</h2>
+					<div className={styles.tableCard}>
+						<table className={styles.table}>
+							<thead>
+								<tr>
+									<th>Client</th>
+									<th className={styles.countCol}>Queries</th>
+								</tr>
+							</thead>
+							<tbody>
+								{rangeLoading || loading ? (
+									<tr>
+										<td colSpan={2} className={styles.tableEmpty}>
+											Loading…
+										</td>
+									</tr>
+								) : (topClients?.clusterClients ?? []).length === 0 ? (
+									<tr>
+										<td colSpan={2} className={styles.tableEmpty}>
+											No data
+										</td>
+									</tr>
+								) : (
+									(topClients?.clusterClients ?? []).map((c) => (
+										<tr key={c.ip}>
+											<td>
+												<span className={styles.clientName}>{c.name || c.ip}</span>
+												{c.name && (
+													<span className={styles.clientIp}>{c.ip}</span>
+												)}
+											</td>
+											<td className={styles.countCol}>{formatCount(c.count)}</td>
+										</tr>
+									))
+								)}
+							</tbody>
+						</table>
+					</div>
+				</section>
+			</div>
+
+			{/* Per-node breakdown */}
+			{summary && summary.nodes.length > 1 && (
+				<section className={styles.section} aria-labelledby='node-breakdown-heading'>
+					<h2 id='node-breakdown-heading' className={styles.sectionTitle}>
+						Per-node Breakdown
+					</h2>
+					<div className={styles.nodeGrid}>
+						{summary.nodes.map(({ node, success, error: nodeErr, data }) => (
+							<div key={node.id} className={styles.nodeCard} data-success={success}>
+								<div className={styles.nodeName}>{node.name}</div>
+								{!success ? (
+									<div className={styles.nodeError}>{nodeErr || 'Unavailable'}</div>
+								) : (
+									<dl className={styles.nodeStats}>
+										<div className={styles.nodeStat}>
+											<dt>Queries</dt>
+											<dd>{formatCount(data.queriesTotal)}</dd>
+										</div>
+										<div className={styles.nodeStat}>
+											<dt>Blocked</dt>
+											<dd>{data.blockedPercent.toFixed(1)}%</dd>
+										</div>
+										<div className={styles.nodeStat}>
+											<dt>Gravity</dt>
+											<dd>{formatCount(data.gravitySize)}</dd>
+										</div>
+										<div className={styles.nodeStat}>
+											<dt>Clients</dt>
+											<dd>{formatCount(data.uniqueClients)}</dd>
+										</div>
+									</dl>
+								)}
+							</div>
+						))}
+					</div>
+				</section>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -156,6 +156,7 @@ export function Stats() {
 				<h2 id='summary-heading' className={styles.sectionTitle}>
 					Cluster Summary
 				</h2>
+				<p className={styles.sectionNote}>Session totals — not filtered by range</p>
 				<div className={styles.summaryCards}>
 					<div className={styles.card}>
 						<div className={styles.statValue}>
@@ -274,12 +275,12 @@ export function Stats() {
 						Top Domains
 					</h2>
 					<div className={styles.tableCard}>
-						<p className={styles.tableSubheading}>Most queried</p>
+						<p className={styles.tableSubheading}>Top permitted</p>
 						<table className={styles.table}>
 							<thead>
 								<tr>
 									<th>Domain</th>
-									<th className={styles.countCol}>Queries</th>
+									<th className={styles.countCol}>Allowed</th>
 								</tr>
 							</thead>
 							<tbody>

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -1,0 +1,60 @@
+export type StatsSummary = {
+	queriesTotal: number;
+	queriesBlocked: number;
+	blockedPercent: number;
+	gravitySize: number;
+	uniqueClients: number;
+	uniqueDomains: number;
+};
+
+export type StatsHistoryPoint = {
+	timestamp: string; // RFC3339
+	total: number;
+	blocked: number;
+};
+
+export type TopDomain = {
+	domain: string;
+	count: number;
+};
+
+export type TopClient = {
+	ip: string;
+	name: string;
+	count: number;
+};
+
+export type StatsNode<T> = {
+	node: { id: number; name: string; host: string };
+	success: boolean;
+	error?: string;
+	data: T;
+};
+
+export type StatsSummaryResponse = {
+	cluster: StatsSummary;
+	nodes: StatsNode<StatsSummary>[];
+};
+
+export type StatsHistoryResponse = {
+	cluster: StatsHistoryPoint[];
+	nodes: StatsNode<StatsHistoryPoint[]>[];
+};
+
+export type StatsTopDomainsNodePayload = {
+	topQueried: TopDomain[];
+	topBlocked: TopDomain[];
+};
+
+export type StatsTopDomainsResponse = {
+	clusterTopQueried: TopDomain[];
+	clusterTopBlocked: TopDomain[];
+	nodes: StatsNode<StatsTopDomainsNodePayload>[];
+};
+
+export type StatsTopClientsResponse = {
+	clusterClients: TopClient[];
+	nodes: StatsNode<TopClient[]>[];
+};
+
+export type StatsRange = '1h' | '6h' | '24h';

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -1,0 +1,5 @@
+export function formatCount(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+	return String(n);
+}


### PR DESCRIPTION
## Summary

- **Stats & Analytics page** (\`/stats\`) — cluster-wide summary cards (session totals, not range-filtered), query history line chart (allowed vs. blocked) with 1h/6h/24h time-range selector, top permitted/blocked domain tables, top clients table, and per-node breakdown when more than one node is configured
- **Home page mini-cards** — total queries, % blocked, and gravity size pulled from the cluster summary on mount, with "View all →" link to \`/stats\`
- **Backend**: four new \`GET /api/v1/stats/*\` endpoints with fan-out across all nodes and partial-failure handling; aggregation in the \`statssvc\` service layer

## Pi-hole FTL v6 endpoints used

| Our endpoint | Pi-hole FTL route |
|---|---|
| \`GET /api/v1/stats/summary\` | \`/api/stats/summary\` (live session counters) |
| \`GET /api/v1/stats/history\` | \`/api/history/database\` (requires \`from\`+\`until\`) |
| \`GET /api/v1/stats/top_domains\` | \`/api/stats/database/top_domains\` × 2 (once plain, once \`?blocked=true\`) |
| \`GET /api/v1/stats/top_clients\` | \`/api/stats/database/top_clients\` |

Wire types were verified against FTL source (`src/api/stats.c`, `history.c`, `stats_database.c`, `api.c`).

## Implementation notes

- The generic \`statsNodeDTO[T]\` in \`stats_dto.go\` follows the same per-node-result pattern used throughout the API
- Summary cards show session-wide counters (Pi-hole \`/api/stats/summary\` is not time-filtered); a "Session totals — not filtered by range" note is shown in the UI
- Top permitted domains show Pi-hole's "allowed" count (\`total − blocked\`), matching Pi-hole's own "Top Permitted Domains" label
- Top-N aggregation is an approximation: a domain outside the per-node top-N but globally top-N may be missed (documented in service layer)

## Test plan

- [ ] \`npm install\` in the devcontainer to pick up recharts
- [ ] \`make dev\` in the devcontainer — backend and Vite both start clean
- [ ] Home page shows three stats mini-cards (may show \`—\` if no Pi-hole data; silently ignored)
- [ ] Sidebar shows "Stats" entry between Domains and Audit Log
- [ ] \`/stats\` page loads: summary cards with session note, chart, top domain/client tables
- [ ] Range buttons (1h/6h/24h) reload chart and tables; summary cards remain unchanged (expected)
- [ ] "Top permitted" table shows allowed domains; "Most blocked" shows blocked domains
- [ ] Refresh button re-fetches all data
- [ ] With two Pi-hole nodes, per-node breakdown grid is visible
- [ ] With one node down, partial-failure banner appears and data from the live node is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)