### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-17
+
 ### Added
 - **Stats & Analytics page** (`/stats`) — cluster-wide query volume, blocked percentage, gravity size, and unique client count summary cards; query history line chart (allowed vs. blocked) with 1h / 6h / 24h time range presets; top queried and top blocked domain tables; top clients table; per-node breakdown section when more than one node is configured.
 - **Home page stats mini-cards** — total queries, blocked percentage, and gravity size sourced from the cluster summary, with a "View all →" link to `/stats`.


### PR DESCRIPTION
Bump CHANGELOG for v0.5.0.

## Changes in this release

- Stats & Analytics page (`/stats`) with summary cards, query history chart, top domains/clients tables, and per-node breakdown
- Home page stats mini-cards (total queries, blocked %, gravity size)
- Stats sidebar nav entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)