### PR TITLE
feat: Client Groups management (Phase 6c)

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -24,7 +24,9 @@ import (
 	clusterblockingsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/clusterblocking"
 	domainrulesvc "github.com/auto-dns/pihole-cluster-admin/internal/service/domainrule"
 	eventssvc "github.com/auto-dns/pihole-cluster-admin/internal/service/events"
+	groupsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/groupsvc"
 	healthsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/health"
+	piholeClientsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/piholeClientsvc"
 	piholesvc "github.com/auto-dns/pihole-cluster-admin/internal/service/pihole"
 	querylogsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/querylog"
 	setupsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/setup"
@@ -100,7 +102,9 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	clusterBlockingService := clusterblockingsvc.NewService(cluster, broker, auditLogService, cfg.Publishers.ClusterBlocking, logger)
 	domainRuleService := domainrulesvc.NewService(cluster, auditLogService)
 	eventsService := eventssvc.NewService(broker, logger)
+	groupService := groupsvc.NewService(cluster, auditLogService)
 	healthService := healthsvc.NewService(broker, cluster, cfg.Publishers.Health, logger)
+	piholeClientService := piholeClientsvc.NewService(cluster, auditLogService)
 	piholeService := piholesvc.NewService(cluster, piholeStore, logger)
 	queryLogService := querylogsvc.NewService(cluster, logger)
 	statsService := statssvc.NewService(cluster, logger)
@@ -153,7 +157,9 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 		AuthService:            authService,
 		ClusterBlockingService: clusterBlockingService,
 		DomainRuleService:      domainRuleService,
+		GroupService:           groupService,
 		HealthService:          healthService,
+		PiholeClientService:    piholeClientService,
 		PiholeService:          piholeService,
 		QueryLogService:        queryLogService,
 		StatsService:           statsService,

--- a/backend/internal/domain/adlist.go
+++ b/backend/internal/domain/adlist.go
@@ -40,6 +40,7 @@ type UpdateAdlistCommand struct {
 	Id      int64
 	Enabled *bool
 	Comment *string
+	Groups  *[]int
 }
 
 type RemoveAdlistCommand struct {

--- a/backend/internal/domain/auditlog.go
+++ b/backend/internal/domain/auditlog.go
@@ -14,6 +14,11 @@ const (
 	AuditActionUpdateAdlist       AuditAction = "update_adlist"
 	AuditActionRemoveAdlist       AuditAction = "remove_adlist"
 	AuditActionRebuildGravity     AuditAction = "rebuild_gravity"
+	AuditActionAddGroup           AuditAction = "add_group"
+	AuditActionUpdateGroup        AuditAction = "update_group"
+	AuditActionRemoveGroup        AuditAction = "remove_group"
+	AuditActionUpdateClient       AuditAction = "update_client"
+	AuditActionRemoveClient       AuditAction = "remove_client"
 )
 
 type AuditNodeResult struct {

--- a/backend/internal/domain/group.go
+++ b/backend/internal/domain/group.go
@@ -1,0 +1,32 @@
+package domain
+
+import "time"
+
+type Group struct {
+	Id           int
+	Name         string
+	Description  *string
+	Enabled      bool
+	DateAdded    time.Time
+	DateModified time.Time
+}
+
+type GroupSet struct {
+	Groups []Group
+}
+
+type AddGroupCommand struct {
+	Name        string
+	Description *string
+	Enabled     bool
+}
+
+type UpdateGroupCommand struct {
+	Name        string
+	Description *string
+	Enabled     *bool
+}
+
+type RemoveGroupCommand struct {
+	Name string
+}

--- a/backend/internal/domain/pihole_client.go
+++ b/backend/internal/domain/pihole_client.go
@@ -1,0 +1,27 @@
+package domain
+
+import "time"
+
+type PiholeClient struct {
+	Id           int64
+	IP           string
+	Name         string
+	Comment      *string
+	Groups       []int
+	DateAdded    time.Time
+	DateModified time.Time
+}
+
+type PiholeClientSet struct {
+	Clients []PiholeClient
+}
+
+type UpdatePiholeClientCommand struct {
+	Id      int64
+	Groups  []int
+	Comment *string
+}
+
+type RemovePiholeClientCommand struct {
+	Id int64
+}

--- a/backend/internal/http/api/v1/adlist_dto.go
+++ b/backend/internal/http/api/v1/adlist_dto.go
@@ -151,6 +151,7 @@ func addAdlistResponseFromDomain(results map[int64]*domain.NodeResult[*domain.Ad
 type updateAdlistRequestDTO struct {
 	Enabled *bool   `json:"enabled,omitempty"`
 	Comment *string `json:"comment,omitempty"`
+	Groups  *[]int  `json:"groups,omitempty"`
 }
 
 // Update reuses addAdlistResponseDTO shape for the returned lists.

--- a/backend/internal/http/api/v1/adlist_handlers.go
+++ b/backend/internal/http/api/v1/adlist_handlers.go
@@ -85,6 +85,7 @@ func adlistUpdate(d Deps) http.HandlerFunc {
 			Id:      id,
 			Enabled: body.Enabled,
 			Comment: body.Comment,
+			Groups:  body.Groups,
 		}
 
 		results := d.AdlistService.Update(r.Context(), cmd)

--- a/backend/internal/http/api/v1/group_dto.go
+++ b/backend/internal/http/api/v1/group_dto.go
@@ -1,0 +1,169 @@
+package v1
+
+import (
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/util"
+)
+
+// Shared group DTO
+
+type groupDTO struct {
+	Id           int     `json:"id"`
+	Name         string  `json:"name"`
+	Description  *string `json:"description"`
+	Enabled      bool    `json:"enabled"`
+	DateAdded    string  `json:"dateAdded"`
+	DateModified string  `json:"dateModified"`
+}
+
+func toGroupDTO(g domain.Group) groupDTO {
+	return groupDTO{
+		Id:           g.Id,
+		Name:         g.Name,
+		Description:  g.Description,
+		Enabled:      g.Enabled,
+		DateAdded:    fmtTime(g.DateAdded),
+		DateModified: fmtTime(g.DateModified),
+	}
+}
+
+// List groups
+
+type listGroupsNodeDTO struct {
+	Node   piholeNodeRefDTO `json:"node"`
+	Groups []groupDTO       `json:"groups"`
+	Error  string           `json:"error,omitempty"`
+}
+
+type listGroupsResponseDTO struct {
+	Summary listGroupsSummaryDTO        `json:"summary"`
+	Nodes   map[int64]listGroupsNodeDTO `json:"nodes"`
+}
+
+type listGroupsSummaryDTO struct {
+	TotalNodes int `json:"totalNodes"`
+	OkNodes    int `json:"okNodes"`
+	ErrorNodes int `json:"errorNodes"`
+}
+
+func listGroupsResponseFromDomain(results map[int64]*domain.NodeResult[*domain.GroupSet]) listGroupsResponseDTO {
+	dto := listGroupsResponseDTO{
+		Nodes: make(map[int64]listGroupsNodeDTO, len(results)),
+	}
+	dto.Summary.TotalNodes = len(results)
+	for id, nr := range results {
+		node := listGroupsNodeDTO{
+			Node: piholeNodeRefDTO{
+				Id:   nr.PiholeNode.Id,
+				Name: nr.PiholeNode.Name,
+				Host: nr.PiholeNode.Host,
+			},
+			Error: util.ErrorString(nr.Error),
+		}
+		if nr.Success && nr.Response != nil {
+			node.Groups = make([]groupDTO, 0, len(nr.Response.Groups))
+			for _, g := range nr.Response.Groups {
+				node.Groups = append(node.Groups, toGroupDTO(g))
+			}
+			dto.Summary.OkNodes++
+		} else {
+			node.Groups = []groupDTO{}
+			dto.Summary.ErrorNodes++
+		}
+		dto.Nodes[id] = node
+	}
+	return dto
+}
+
+// Add / update group — share same response shape
+
+type addGroupRequestDTO struct {
+	Name        string  `json:"name"`
+	Description *string `json:"description,omitempty"`
+	Enabled     *bool   `json:"enabled,omitempty"`
+}
+
+type updateGroupRequestDTO struct {
+	Description *string `json:"description,omitempty"`
+	Enabled     *bool   `json:"enabled,omitempty"`
+}
+
+type groupMutateNodeDTO struct {
+	Node   piholeNodeRefDTO `json:"node"`
+	Groups []groupDTO       `json:"groups"`
+	Error  string           `json:"error,omitempty"`
+}
+
+type groupMutateResponseDTO struct {
+	Nodes map[int64]groupMutateNodeDTO `json:"nodes"`
+}
+
+func groupMutateResponseFromDomain(results map[int64]*domain.NodeResult[*domain.GroupSet]) groupMutateResponseDTO {
+	dto := groupMutateResponseDTO{
+		Nodes: make(map[int64]groupMutateNodeDTO, len(results)),
+	}
+	for id, nr := range results {
+		node := groupMutateNodeDTO{
+			Node: piholeNodeRefDTO{
+				Id:   nr.PiholeNode.Id,
+				Name: nr.PiholeNode.Name,
+				Host: nr.PiholeNode.Host,
+			},
+			Error: util.ErrorString(nr.Error),
+		}
+		if nr.Success && nr.Response != nil {
+			node.Groups = make([]groupDTO, 0, len(nr.Response.Groups))
+			for _, g := range nr.Response.Groups {
+				node.Groups = append(node.Groups, toGroupDTO(g))
+			}
+		} else {
+			node.Groups = []groupDTO{}
+		}
+		dto.Nodes[id] = node
+	}
+	return dto
+}
+
+// Remove group
+
+type removeGroupNodeDTO struct {
+	Node    piholeNodeRefDTO `json:"node"`
+	Removed bool             `json:"removed"`
+	Error   string           `json:"error,omitempty"`
+}
+
+type removeGroupResponseDTO struct {
+	Summary removeGroupSummaryDTO        `json:"summary"`
+	Nodes   map[int64]removeGroupNodeDTO `json:"nodes"`
+}
+
+type removeGroupSummaryDTO struct {
+	Total   int `json:"total"`
+	Removed int `json:"removed"`
+	Failed  int `json:"failed"`
+}
+
+func removeGroupResponseFromDomain(results map[int64]*domain.NodeResult[struct{}]) removeGroupResponseDTO {
+	dto := removeGroupResponseDTO{
+		Nodes: make(map[int64]removeGroupNodeDTO, len(results)),
+	}
+	dto.Summary.Total = len(results)
+	for id, nr := range results {
+		node := removeGroupNodeDTO{
+			Node: piholeNodeRefDTO{
+				Id:   nr.PiholeNode.Id,
+				Name: nr.PiholeNode.Name,
+				Host: nr.PiholeNode.Host,
+			},
+			Removed: nr.Success,
+			Error:   util.ErrorString(nr.Error),
+		}
+		if nr.Success {
+			dto.Summary.Removed++
+		} else {
+			dto.Summary.Failed++
+		}
+		dto.Nodes[id] = node
+	}
+	return dto
+}

--- a/backend/internal/http/api/v1/group_handlers.go
+++ b/backend/internal/http/api/v1/group_handlers.go
@@ -88,6 +88,10 @@ func groupRemove(d Deps) http.HandlerFunc {
 			transport.WriteBadRequestErr(w, "group name is required", errors.New("group name is required"))
 			return
 		}
+		if name == "Default" {
+			transport.WriteBadRequestErr(w, "the Default group cannot be removed", errors.New("the Default group cannot be removed"))
+			return
+		}
 
 		cmd := domain.RemoveGroupCommand{Name: name}
 		results := d.GroupService.Remove(r.Context(), cmd)

--- a/backend/internal/http/api/v1/group_handlers.go
+++ b/backend/internal/http/api/v1/group_handlers.go
@@ -1,0 +1,96 @@
+package v1
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/http/transport"
+	"github.com/go-chi/chi"
+)
+
+func registerGroups(r chi.Router, d Deps) {
+	r.Route("/groups", func(r chi.Router) {
+		r.Get("/", groupList(d))
+		r.Post("/", groupAdd(d))
+		r.Put("/{name}", groupUpdate(d))
+		r.Delete("/{name}", groupRemove(d))
+	})
+}
+
+func groupList(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		results := d.GroupService.List(r.Context())
+		transport.WriteJSON(w, http.StatusOK, listGroupsResponseFromDomain(results))
+	}
+}
+
+func groupAdd(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body addGroupRequestDTO
+		if err := transport.DecodeJSONBody(w, r, &body, 1<<20); err != nil {
+			d.Logger.Error().Err(err).Msg("invalid JSON body")
+			transport.WriteErr(w, err)
+			return
+		}
+
+		if body.Name == "" {
+			transport.WriteBadRequestErr(w, "\"name\" is required", errors.New("\"name\" is required"))
+			return
+		}
+
+		enabled := true
+		if body.Enabled != nil {
+			enabled = *body.Enabled
+		}
+
+		cmd := domain.AddGroupCommand{
+			Name:        body.Name,
+			Description: body.Description,
+			Enabled:     enabled,
+		}
+
+		results := d.GroupService.Add(r.Context(), cmd)
+		transport.WriteJSON(w, http.StatusOK, groupMutateResponseFromDomain(results))
+	}
+}
+
+func groupUpdate(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name := chi.URLParam(r, "name")
+		if name == "" {
+			transport.WriteBadRequestErr(w, "group name is required", errors.New("group name is required"))
+			return
+		}
+
+		var body updateGroupRequestDTO
+		if err := transport.DecodeJSONBody(w, r, &body, 1<<20); err != nil {
+			d.Logger.Error().Err(err).Msg("invalid JSON body")
+			transport.WriteErr(w, err)
+			return
+		}
+
+		cmd := domain.UpdateGroupCommand{
+			Name:        name,
+			Description: body.Description,
+			Enabled:     body.Enabled,
+		}
+
+		results := d.GroupService.Update(r.Context(), cmd)
+		transport.WriteJSON(w, http.StatusOK, groupMutateResponseFromDomain(results))
+	}
+}
+
+func groupRemove(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name := chi.URLParam(r, "name")
+		if name == "" {
+			transport.WriteBadRequestErr(w, "group name is required", errors.New("group name is required"))
+			return
+		}
+
+		cmd := domain.RemoveGroupCommand{Name: name}
+		results := d.GroupService.Remove(r.Context(), cmd)
+		transport.WriteJSON(w, http.StatusOK, removeGroupResponseFromDomain(results))
+	}
+}

--- a/backend/internal/http/api/v1/interface.go
+++ b/backend/internal/http/api/v1/interface.go
@@ -19,6 +19,19 @@ type adlistService interface {
 	RebuildGravity(ctx context.Context) map[int64]*domain.NodeResult[struct{}]
 }
 
+type groupService interface {
+	List(ctx context.Context) map[int64]*domain.NodeResult[*domain.GroupSet]
+	Add(ctx context.Context, cmd domain.AddGroupCommand) map[int64]*domain.NodeResult[*domain.GroupSet]
+	Update(ctx context.Context, cmd domain.UpdateGroupCommand) map[int64]*domain.NodeResult[*domain.GroupSet]
+	Remove(ctx context.Context, cmd domain.RemoveGroupCommand) map[int64]*domain.NodeResult[struct{}]
+}
+
+type piholeClientService interface {
+	List(ctx context.Context) map[int64]*domain.NodeResult[*domain.PiholeClientSet]
+	Update(ctx context.Context, cmd domain.UpdatePiholeClientCommand) map[int64]*domain.NodeResult[*domain.PiholeClientSet]
+	Remove(ctx context.Context, cmd domain.RemovePiholeClientCommand) map[int64]*domain.NodeResult[struct{}]
+}
+
 type auditLogService interface {
 	GetById(ctx context.Context, id int64) (*domain.AuditEntry, error)
 	List(ctx context.Context, q domain.ListAuditEntriesQuery) ([]*domain.AuditEntry, int, error)

--- a/backend/internal/http/api/v1/pihole_client_dto.go
+++ b/backend/internal/http/api/v1/pihole_client_dto.go
@@ -1,0 +1,169 @@
+package v1
+
+import (
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/util"
+)
+
+// Shared client DTO
+
+type piholeClientDTO struct {
+	Id           int64   `json:"id"`
+	IP           string  `json:"ip"`
+	Name         string  `json:"name"`
+	Comment      *string `json:"comment"`
+	Groups       []int   `json:"groups"`
+	DateAdded    string  `json:"dateAdded"`
+	DateModified string  `json:"dateModified"`
+}
+
+func toPiholeClientDTO(c domain.PiholeClient) piholeClientDTO {
+	groups := c.Groups
+	if groups == nil {
+		groups = []int{}
+	}
+	return piholeClientDTO{
+		Id:           c.Id,
+		IP:           c.IP,
+		Name:         c.Name,
+		Comment:      c.Comment,
+		Groups:       groups,
+		DateAdded:    fmtTime(c.DateAdded),
+		DateModified: fmtTime(c.DateModified),
+	}
+}
+
+// List clients
+
+type listClientsNodeDTO struct {
+	Node    piholeNodeRefDTO  `json:"node"`
+	Clients []piholeClientDTO `json:"clients"`
+	Error   string            `json:"error,omitempty"`
+}
+
+type listClientsResponseDTO struct {
+	Summary listClientsSummaryDTO        `json:"summary"`
+	Nodes   map[int64]listClientsNodeDTO `json:"nodes"`
+}
+
+type listClientsSummaryDTO struct {
+	TotalNodes int `json:"totalNodes"`
+	OkNodes    int `json:"okNodes"`
+	ErrorNodes int `json:"errorNodes"`
+}
+
+func listClientsResponseFromDomain(results map[int64]*domain.NodeResult[*domain.PiholeClientSet]) listClientsResponseDTO {
+	dto := listClientsResponseDTO{
+		Nodes: make(map[int64]listClientsNodeDTO, len(results)),
+	}
+	dto.Summary.TotalNodes = len(results)
+	for id, nr := range results {
+		node := listClientsNodeDTO{
+			Node: piholeNodeRefDTO{
+				Id:   nr.PiholeNode.Id,
+				Name: nr.PiholeNode.Name,
+				Host: nr.PiholeNode.Host,
+			},
+			Error: util.ErrorString(nr.Error),
+		}
+		if nr.Success && nr.Response != nil {
+			node.Clients = make([]piholeClientDTO, 0, len(nr.Response.Clients))
+			for _, c := range nr.Response.Clients {
+				node.Clients = append(node.Clients, toPiholeClientDTO(c))
+			}
+			dto.Summary.OkNodes++
+		} else {
+			node.Clients = []piholeClientDTO{}
+			dto.Summary.ErrorNodes++
+		}
+		dto.Nodes[id] = node
+	}
+	return dto
+}
+
+// Update client
+
+type updateClientRequestDTO struct {
+	Groups  []int   `json:"groups"`
+	Comment *string `json:"comment,omitempty"`
+}
+
+type clientMutateNodeDTO struct {
+	Node    piholeNodeRefDTO  `json:"node"`
+	Clients []piholeClientDTO `json:"clients"`
+	Error   string            `json:"error,omitempty"`
+}
+
+type clientMutateResponseDTO struct {
+	Nodes map[int64]clientMutateNodeDTO `json:"nodes"`
+}
+
+func clientMutateResponseFromDomain(results map[int64]*domain.NodeResult[*domain.PiholeClientSet]) clientMutateResponseDTO {
+	dto := clientMutateResponseDTO{
+		Nodes: make(map[int64]clientMutateNodeDTO, len(results)),
+	}
+	for id, nr := range results {
+		node := clientMutateNodeDTO{
+			Node: piholeNodeRefDTO{
+				Id:   nr.PiholeNode.Id,
+				Name: nr.PiholeNode.Name,
+				Host: nr.PiholeNode.Host,
+			},
+			Error: util.ErrorString(nr.Error),
+		}
+		if nr.Success && nr.Response != nil {
+			node.Clients = make([]piholeClientDTO, 0, len(nr.Response.Clients))
+			for _, c := range nr.Response.Clients {
+				node.Clients = append(node.Clients, toPiholeClientDTO(c))
+			}
+		} else {
+			node.Clients = []piholeClientDTO{}
+		}
+		dto.Nodes[id] = node
+	}
+	return dto
+}
+
+// Remove client
+
+type removeClientNodeDTO struct {
+	Node    piholeNodeRefDTO `json:"node"`
+	Removed bool             `json:"removed"`
+	Error   string           `json:"error,omitempty"`
+}
+
+type removeClientResponseDTO struct {
+	Summary removeClientSummaryDTO        `json:"summary"`
+	Nodes   map[int64]removeClientNodeDTO `json:"nodes"`
+}
+
+type removeClientSummaryDTO struct {
+	Total   int `json:"total"`
+	Removed int `json:"removed"`
+	Failed  int `json:"failed"`
+}
+
+func removeClientResponseFromDomain(results map[int64]*domain.NodeResult[struct{}]) removeClientResponseDTO {
+	dto := removeClientResponseDTO{
+		Nodes: make(map[int64]removeClientNodeDTO, len(results)),
+	}
+	dto.Summary.Total = len(results)
+	for id, nr := range results {
+		node := removeClientNodeDTO{
+			Node: piholeNodeRefDTO{
+				Id:   nr.PiholeNode.Id,
+				Name: nr.PiholeNode.Name,
+				Host: nr.PiholeNode.Host,
+			},
+			Removed: nr.Success,
+			Error:   util.ErrorString(nr.Error),
+		}
+		if nr.Success {
+			dto.Summary.Removed++
+		} else {
+			dto.Summary.Failed++
+		}
+		dto.Nodes[id] = node
+	}
+	return dto
+}

--- a/backend/internal/http/api/v1/pihole_client_handlers.go
+++ b/backend/internal/http/api/v1/pihole_client_handlers.go
@@ -1,0 +1,73 @@
+package v1
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/http/transport"
+	"github.com/go-chi/chi"
+)
+
+func registerPiholeClients(r chi.Router, d Deps) {
+	r.Route("/clients", func(r chi.Router) {
+		r.Get("/", clientList(d))
+		r.Put("/{id}", clientUpdate(d))
+		r.Delete("/{id}", clientRemove(d))
+	})
+}
+
+func clientList(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		results := d.PiholeClientService.List(r.Context())
+		transport.WriteJSON(w, http.StatusOK, listClientsResponseFromDomain(results))
+	}
+}
+
+func clientUpdate(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idStr := chi.URLParam(r, "id")
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil || id <= 0 {
+			transport.WriteBadRequestErr(w, "invalid client id", errors.New("invalid client id"))
+			return
+		}
+
+		var body updateClientRequestDTO
+		if err := transport.DecodeJSONBody(w, r, &body, 1<<20); err != nil {
+			d.Logger.Error().Err(err).Msg("invalid JSON body")
+			transport.WriteErr(w, err)
+			return
+		}
+
+		groups := body.Groups
+		if groups == nil {
+			groups = []int{}
+		}
+
+		cmd := domain.UpdatePiholeClientCommand{
+			Id:      id,
+			Groups:  groups,
+			Comment: body.Comment,
+		}
+
+		results := d.PiholeClientService.Update(r.Context(), cmd)
+		transport.WriteJSON(w, http.StatusOK, clientMutateResponseFromDomain(results))
+	}
+}
+
+func clientRemove(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idStr := chi.URLParam(r, "id")
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil || id <= 0 {
+			transport.WriteBadRequestErr(w, "invalid client id", errors.New("invalid client id"))
+			return
+		}
+
+		cmd := domain.RemovePiholeClientCommand{Id: id}
+		results := d.PiholeClientService.Remove(r.Context(), cmd)
+		transport.WriteJSON(w, http.StatusOK, removeClientResponseFromDomain(results))
+	}
+}

--- a/backend/internal/http/api/v1/router.go
+++ b/backend/internal/http/api/v1/router.go
@@ -14,7 +14,9 @@ type Deps struct {
 	AuthService            authService
 	ClusterBlockingService clusterBlockingService
 	DomainRuleService      domainRuleService
+	GroupService           groupService
 	HealthService          healthService
+	PiholeClientService    piholeClientService
 	PiholeService          piholeService
 	QueryLogService        queryLogService
 	StatsService           statsService
@@ -47,6 +49,8 @@ func RegisterAPIV1(r chi.Router, d Deps) {
 		registerAuditLog(r, d)
 		registerAuthPrivate(r, d)
 		registerClusterBlocking(r, d)
+		registerPiholeClients(r, d)
+		registerGroups(r, d)
 		registerHealth(r, d)
 		registerDomainRules(r, d)
 		registerPihole(r, d)

--- a/backend/internal/pihole/client.go
+++ b/backend/internal/pihole/client.go
@@ -1020,6 +1020,7 @@ func (c *Client) UpdateAdlist(ctx context.Context, cmd domain.UpdateAdlistComman
 	wreq := updateAdlistWireRequest{
 		Enabled: cmd.Enabled,
 		Comment: cmd.Comment,
+		Groups:  cmd.Groups,
 	}
 	body, err := json.Marshal(wreq)
 	if err != nil {
@@ -1089,6 +1090,242 @@ func (c *Client) RebuildGravity(ctx context.Context) error {
 	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		return &httpStatusError{Status: resp.StatusCode}
+	}
+	return nil
+}
+
+// Groups
+
+func toGroup(w groupWireEntry) domain.Group {
+	return domain.Group{
+		Id:           w.Id,
+		Name:         w.Name,
+		Description:  w.Description,
+		Enabled:      w.Enabled,
+		DateAdded:    time.Unix(w.DateAdded, 0).UTC(),
+		DateModified: time.Unix(w.DateModified, 0).UTC(),
+	}
+}
+
+func toGroupSet(w groupsWireResponse) domain.GroupSet {
+	out := domain.GroupSet{Groups: make([]domain.Group, 0, len(w.Groups))}
+	for _, g := range w.Groups {
+		out.Groups = append(out.Groups, toGroup(g))
+	}
+	return out
+}
+
+func (c *Client) ListGroups(ctx context.Context) (*domain.GroupSet, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.getBaseURL()+"/groups", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("listing groups: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var w groupsWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	gs := toGroupSet(w)
+	return &gs, nil
+}
+
+func (c *Client) AddGroup(ctx context.Context, cmd domain.AddGroupCommand) (*domain.GroupSet, error) {
+	wreq := addGroupWireRequest{
+		Name:        cmd.Name,
+		Description: cmd.Description,
+		Enabled:     cmd.Enabled,
+	}
+	body, err := json.Marshal(wreq)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.getBaseURL()+"/groups", bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("adding group: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var w groupsWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	gs := toGroupSet(w)
+	return &gs, nil
+}
+
+func (c *Client) UpdateGroup(ctx context.Context, cmd domain.UpdateGroupCommand) (*domain.GroupSet, error) {
+	wreq := updateGroupWireRequest{
+		Description: cmd.Description,
+		Enabled:     cmd.Enabled,
+	}
+	body, err := json.Marshal(wreq)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+	u := fmt.Sprintf("%s/groups/%s", c.getBaseURL(), url.PathEscape(cmd.Name))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("updating group: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var w groupsWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	gs := toGroupSet(w)
+	return &gs, nil
+}
+
+func (c *Client) RemoveGroup(ctx context.Context, cmd domain.RemoveGroupCommand) error {
+	u := fmt.Sprintf("%s/groups/%s", c.getBaseURL(), url.PathEscape(cmd.Name))
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return fmt.Errorf("removing group: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	return nil
+}
+
+// Clients
+
+func toClient(w clientWireEntry) domain.PiholeClient {
+	groups := w.Groups
+	if groups == nil {
+		groups = []int{}
+	}
+	return domain.PiholeClient{
+		Id:           w.Id,
+		IP:           w.IP,
+		Name:         w.Name,
+		Comment:      w.Comment,
+		Groups:       groups,
+		DateAdded:    time.Unix(w.DateAdded, 0).UTC(),
+		DateModified: time.Unix(w.DateModified, 0).UTC(),
+	}
+}
+
+func toClientSet(w clientsWireResponse) domain.PiholeClientSet {
+	out := domain.PiholeClientSet{Clients: make([]domain.PiholeClient, 0, len(w.Clients))}
+	for _, c := range w.Clients {
+		out.Clients = append(out.Clients, toClient(c))
+	}
+	return out
+}
+
+func (c *Client) ListPiholeClients(ctx context.Context) (*domain.PiholeClientSet, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.getBaseURL()+"/clients", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("listing clients: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var w clientsWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	cs := toClientSet(w)
+	return &cs, nil
+}
+
+func (c *Client) UpdatePiholeClient(ctx context.Context, cmd domain.UpdatePiholeClientCommand) (*domain.PiholeClientSet, error) {
+	groups := cmd.Groups
+	if groups == nil {
+		groups = []int{}
+	}
+	wreq := updateClientWireRequest{
+		Groups:  groups,
+		Comment: cmd.Comment,
+	}
+	body, err := json.Marshal(wreq)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+	u := fmt.Sprintf("%s/clients/%d", c.getBaseURL(), cmd.Id)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("updating client: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var w clientsWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	cs := toClientSet(w)
+	return &cs, nil
+}
+
+func (c *Client) RemovePiholeClient(ctx context.Context, cmd domain.RemovePiholeClientCommand) error {
+	u := fmt.Sprintf("%s/clients/%d", c.getBaseURL(), cmd.Id)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return fmt.Errorf("removing client: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return &httpStatusError{Status: resp.StatusCode, Body: string(b)}
 	}
 	return nil
 }

--- a/backend/internal/pihole/cluster.go
+++ b/backend/internal/pihole/cluster.go
@@ -407,6 +407,59 @@ func (c *Cluster) RebuildGravity(ctx context.Context) map[int64]*domain.NodeResu
 	return out
 }
 
+// Groups
+
+func (c *Cluster) ListGroups(ctx context.Context) map[int64]*domain.NodeResult[*domain.GroupSet] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.GroupSet, error) {
+		return client.ListGroups(nodeCtx)
+	})
+	return out
+}
+
+func (c *Cluster) AddGroup(ctx context.Context, cmd domain.AddGroupCommand) map[int64]*domain.NodeResult[*domain.GroupSet] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.GroupSet, error) {
+		return client.AddGroup(nodeCtx, cmd)
+	})
+	return out
+}
+
+func (c *Cluster) UpdateGroup(ctx context.Context, cmd domain.UpdateGroupCommand) map[int64]*domain.NodeResult[*domain.GroupSet] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.GroupSet, error) {
+		return client.UpdateGroup(nodeCtx, cmd)
+	})
+	return out
+}
+
+func (c *Cluster) RemoveGroup(ctx context.Context, cmd domain.RemoveGroupCommand) map[int64]*domain.NodeResult[struct{}] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (struct{}, error) {
+		return struct{}{}, client.RemoveGroup(nodeCtx, cmd)
+	})
+	return out
+}
+
+// PiholeClients (Pi-hole's configured client list, distinct from Cluster node management)
+
+func (c *Cluster) ListPiholeClients(ctx context.Context) map[int64]*domain.NodeResult[*domain.PiholeClientSet] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.PiholeClientSet, error) {
+		return client.ListPiholeClients(nodeCtx)
+	})
+	return out
+}
+
+func (c *Cluster) UpdatePiholeClient(ctx context.Context, cmd domain.UpdatePiholeClientCommand) map[int64]*domain.NodeResult[*domain.PiholeClientSet] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.PiholeClientSet, error) {
+		return client.UpdatePiholeClient(nodeCtx, cmd)
+	})
+	return out
+}
+
+func (c *Cluster) RemovePiholeClient(ctx context.Context, cmd domain.RemovePiholeClientCommand) map[int64]*domain.NodeResult[struct{}] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (struct{}, error) {
+		return struct{}{}, client.RemovePiholeClient(nodeCtx, cmd)
+	})
+	return out
+}
+
 func (c *Cluster) AuthStatus(ctx context.Context) map[int64]*domain.NodeResult[*domain.AuthStatus] {
 	c.logger.Trace().Msg("getting auth status for cluster")
 	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.AuthStatus, error) {

--- a/backend/internal/pihole/interface.go
+++ b/backend/internal/pihole/interface.go
@@ -32,6 +32,13 @@ type clientPort interface {
 	GetStatsHistory(ctx context.Context, from, until *int64) (*domain.StatsHistory, error)
 	GetStatsTopDomains(ctx context.Context, from, until *int64, count *int) (*domain.StatsTopDomains, error)
 	GetStatsTopClients(ctx context.Context, from, until *int64, count *int) (*domain.StatsTopClients, error)
+	ListGroups(ctx context.Context) (*domain.GroupSet, error)
+	AddGroup(ctx context.Context, cmd domain.AddGroupCommand) (*domain.GroupSet, error)
+	UpdateGroup(ctx context.Context, cmd domain.UpdateGroupCommand) (*domain.GroupSet, error)
+	RemoveGroup(ctx context.Context, cmd domain.RemoveGroupCommand) error
+	ListPiholeClients(ctx context.Context) (*domain.PiholeClientSet, error)
+	UpdatePiholeClient(ctx context.Context, cmd domain.UpdatePiholeClientCommand) (*domain.PiholeClientSet, error)
+	RemovePiholeClient(ctx context.Context, cmd domain.RemovePiholeClientCommand) error
 }
 
 type cursorManagerPort[T any] interface {

--- a/backend/internal/pihole/wire.go
+++ b/backend/internal/pihole/wire.go
@@ -223,6 +223,56 @@ type addAdlistWireRequest struct {
 type updateAdlistWireRequest struct {
 	Enabled *bool   `json:"enabled,omitempty"`
 	Comment *string `json:"comment,omitempty"`
+	Groups  *[]int  `json:"groups,omitempty"`
+}
+
+// Groups
+
+type groupWireEntry struct {
+	Id           int     `json:"id"`
+	Name         string  `json:"name"`
+	Description  *string `json:"description"`
+	Enabled      bool    `json:"enabled"`
+	DateAdded    int64   `json:"date_added"`
+	DateModified int64   `json:"date_modified"`
+}
+
+type groupsWireResponse struct {
+	Groups []groupWireEntry `json:"groups"`
+	Took   float64          `json:"took"`
+}
+
+type addGroupWireRequest struct {
+	Name        string  `json:"name"`
+	Description *string `json:"description,omitempty"`
+	Enabled     bool    `json:"enabled"`
+}
+
+type updateGroupWireRequest struct {
+	Description *string `json:"description,omitempty"`
+	Enabled     *bool   `json:"enabled,omitempty"`
+}
+
+// Clients
+
+type clientWireEntry struct {
+	Id           int64   `json:"id"`
+	IP           string  `json:"ip"`
+	Name         string  `json:"name"`
+	Comment      *string `json:"comment"`
+	Groups       []int   `json:"groups"`
+	DateAdded    int64   `json:"date_added"`
+	DateModified int64   `json:"date_modified"`
+}
+
+type clientsWireResponse struct {
+	Clients []clientWireEntry `json:"clients"`
+	Took    float64           `json:"took"`
+}
+
+type updateClientWireRequest struct {
+	Groups  []int   `json:"groups"`
+	Comment *string `json:"comment,omitempty"`
 }
 
 type addDomainsWireResponse struct {

--- a/backend/internal/service/groupsvc/interface.go
+++ b/backend/internal/service/groupsvc/interface.go
@@ -1,0 +1,18 @@
+package groupsvc
+
+import (
+	"context"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+)
+
+type cluster interface {
+	ListGroups(ctx context.Context) map[int64]*domain.NodeResult[*domain.GroupSet]
+	AddGroup(ctx context.Context, cmd domain.AddGroupCommand) map[int64]*domain.NodeResult[*domain.GroupSet]
+	UpdateGroup(ctx context.Context, cmd domain.UpdateGroupCommand) map[int64]*domain.NodeResult[*domain.GroupSet]
+	RemoveGroup(ctx context.Context, cmd domain.RemoveGroupCommand) map[int64]*domain.NodeResult[struct{}]
+}
+
+type auditLogger interface {
+	Record(ctx context.Context, params domain.CreateAuditEntryParams)
+}

--- a/backend/internal/service/groupsvc/service.go
+++ b/backend/internal/service/groupsvc/service.go
@@ -1,0 +1,74 @@
+package groupsvc
+
+import (
+	"context"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/util"
+)
+
+type Service struct {
+	cluster cluster
+	audit   auditLogger
+}
+
+func NewService(cluster cluster, audit auditLogger) *Service {
+	return &Service{cluster: cluster, audit: audit}
+}
+
+func (s *Service) List(ctx context.Context) map[int64]*domain.NodeResult[*domain.GroupSet] {
+	return s.cluster.ListGroups(ctx)
+}
+
+func (s *Service) Add(ctx context.Context, cmd domain.AddGroupCommand) map[int64]*domain.NodeResult[*domain.GroupSet] {
+	results := s.cluster.AddGroup(ctx, cmd)
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:      domain.AuditActionAddGroup,
+		NodeResults: nodeResultsFromGroupSet(results),
+	})
+	return results
+}
+
+func (s *Service) Update(ctx context.Context, cmd domain.UpdateGroupCommand) map[int64]*domain.NodeResult[*domain.GroupSet] {
+	results := s.cluster.UpdateGroup(ctx, cmd)
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:      domain.AuditActionUpdateGroup,
+		NodeResults: nodeResultsFromGroupSet(results),
+	})
+	return results
+}
+
+func (s *Service) Remove(ctx context.Context, cmd domain.RemoveGroupCommand) map[int64]*domain.NodeResult[struct{}] {
+	results := s.cluster.RemoveGroup(ctx, cmd)
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:      domain.AuditActionRemoveGroup,
+		NodeResults: nodeResultsFromRemove(results),
+	})
+	return results
+}
+
+func nodeResultsFromGroupSet(results map[int64]*domain.NodeResult[*domain.GroupSet]) []domain.AuditNodeResult {
+	out := make([]domain.AuditNodeResult, 0, len(results))
+	for _, nr := range results {
+		out = append(out, domain.AuditNodeResult{
+			NodeId:   nr.PiholeNode.Id,
+			NodeName: nr.PiholeNode.Name,
+			Success:  nr.Success,
+			Error:    util.ErrorString(nr.Error),
+		})
+	}
+	return out
+}
+
+func nodeResultsFromRemove(results map[int64]*domain.NodeResult[struct{}]) []domain.AuditNodeResult {
+	out := make([]domain.AuditNodeResult, 0, len(results))
+	for _, nr := range results {
+		out = append(out, domain.AuditNodeResult{
+			NodeId:   nr.PiholeNode.Id,
+			NodeName: nr.PiholeNode.Name,
+			Success:  nr.Success,
+			Error:    util.ErrorString(nr.Error),
+		})
+	}
+	return out
+}

--- a/backend/internal/service/piholeClientsvc/interface.go
+++ b/backend/internal/service/piholeClientsvc/interface.go
@@ -1,0 +1,17 @@
+package piholeClientsvc
+
+import (
+	"context"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+)
+
+type cluster interface {
+	ListPiholeClients(ctx context.Context) map[int64]*domain.NodeResult[*domain.PiholeClientSet]
+	UpdatePiholeClient(ctx context.Context, cmd domain.UpdatePiholeClientCommand) map[int64]*domain.NodeResult[*domain.PiholeClientSet]
+	RemovePiholeClient(ctx context.Context, cmd domain.RemovePiholeClientCommand) map[int64]*domain.NodeResult[struct{}]
+}
+
+type auditLogger interface {
+	Record(ctx context.Context, params domain.CreateAuditEntryParams)
+}

--- a/backend/internal/service/piholeClientsvc/service.go
+++ b/backend/internal/service/piholeClientsvc/service.go
@@ -1,0 +1,65 @@
+package piholeClientsvc
+
+import (
+	"context"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/util"
+)
+
+type Service struct {
+	cluster cluster
+	audit   auditLogger
+}
+
+func NewService(cluster cluster, audit auditLogger) *Service {
+	return &Service{cluster: cluster, audit: audit}
+}
+
+func (s *Service) List(ctx context.Context) map[int64]*domain.NodeResult[*domain.PiholeClientSet] {
+	return s.cluster.ListPiholeClients(ctx)
+}
+
+func (s *Service) Update(ctx context.Context, cmd domain.UpdatePiholeClientCommand) map[int64]*domain.NodeResult[*domain.PiholeClientSet] {
+	results := s.cluster.UpdatePiholeClient(ctx, cmd)
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:      domain.AuditActionUpdateClient,
+		NodeResults: nodeResultsFromClientSet(results),
+	})
+	return results
+}
+
+func (s *Service) Remove(ctx context.Context, cmd domain.RemovePiholeClientCommand) map[int64]*domain.NodeResult[struct{}] {
+	results := s.cluster.RemovePiholeClient(ctx, cmd)
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:      domain.AuditActionRemoveClient,
+		NodeResults: nodeResultsFromRemove(results),
+	})
+	return results
+}
+
+func nodeResultsFromClientSet(results map[int64]*domain.NodeResult[*domain.PiholeClientSet]) []domain.AuditNodeResult {
+	out := make([]domain.AuditNodeResult, 0, len(results))
+	for _, nr := range results {
+		out = append(out, domain.AuditNodeResult{
+			NodeId:   nr.PiholeNode.Id,
+			NodeName: nr.PiholeNode.Name,
+			Success:  nr.Success,
+			Error:    util.ErrorString(nr.Error),
+		})
+	}
+	return out
+}
+
+func nodeResultsFromRemove(results map[int64]*domain.NodeResult[struct{}]) []domain.AuditNodeResult {
+	out := make([]domain.AuditNodeResult, 0, len(results))
+	for _, nr := range results {
+		out = append(out, domain.AuditNodeResult{
+			NodeId:   nr.PiholeNode.Id,
+			NodeName: nr.PiholeNode.Name,
+			Success:  nr.Success,
+			Error:    util.ErrorString(nr.Error),
+		})
+	}
+	return out
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -17,6 +17,7 @@ import { UnhandledRoute } from './routes/UnhandledRoute';
 import { Account } from '@/pages/Account/Account';
 import { Adlists } from '@/pages/Adlists';
 import { Audit } from '@/pages/Audit';
+import { Clients } from '@/pages/Clients';
 import { Stats } from '@/pages/Stats';
 
 export const router = createBrowserRouter([
@@ -65,6 +66,11 @@ export const router = createBrowserRouter([
 						path: '/audit',
 						Component: Audit,
 						handle: { layoutOptions: { pageTitle: 'Audit Log' } },
+					},
+					{
+						path: '/clients',
+						Component: Clients,
+						handle: { layoutOptions: { pageTitle: 'Clients' } },
 					},
 					{
 						path: '/account',

--- a/frontend/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
 	FileText,
 	Home,
 	List,
+	Monitor,
 	Shield,
 	ShieldAlert,
 	SettingsIcon,
@@ -23,15 +24,16 @@ import { ClusterHeader } from '@/components/ClusterHeader';
 import styles from './Sidebar.module.scss';
 
 const links = [
-	{ to: '/', label: 'Home', icon: Home, end: true },
-	{ to: '/blocking', label: 'Blocking', icon: Shield, end: false },
-	{ to: '/recent-blocks', label: 'Recent Blocks', icon: ShieldAlert },
-	{ to: '/query', label: 'Query Log', icon: FileText },
-	{ to: '/domains', label: 'Domains', icon: List },
-	{ to: '/stats', label: 'Stats', icon: BarChart2 },
 	{ to: '/adlists', label: 'Adlists', icon: Database },
 	{ to: '/audit', label: 'Audit Log', icon: Clock },
+	{ to: '/blocking', label: 'Blocking', icon: Shield },
+	{ to: '/clients', label: 'Clients', icon: Monitor },
+	{ to: '/domains', label: 'Domains', icon: List },
+	{ to: '/', label: 'Home', icon: Home, end: true },
+	{ to: '/query', label: 'Query Log', icon: FileText },
+	{ to: '/recent-blocks', label: 'Recent Blocks', icon: ShieldAlert },
 	{ to: '/settings', label: 'Settings', icon: SettingsIcon },
+	{ to: '/stats', label: 'Stats', icon: BarChart2 },
 ];
 
 const accountLinks = [{ to: '/account', label: 'Account', icon: User }];

--- a/frontend/src/lib/api/adlists.ts
+++ b/frontend/src/lib/api/adlists.ts
@@ -25,7 +25,7 @@ export async function addAdlist(
 
 export async function updateAdlist(
 	id: number,
-	patch: { enabled?: boolean; comment?: string | null },
+	patch: { enabled?: boolean; comment?: string | null; groups?: number[] },
 ): Promise<AddAdlistResponse> {
 	return apiV1Fetch<AddAdlistResponse>(`/adlists/${id}`, {
 		method: 'PUT',

--- a/frontend/src/lib/api/adlists.ts
+++ b/frontend/src/lib/api/adlists.ts
@@ -15,11 +15,18 @@ export async function addAdlist(
 	address: string,
 	type: AdlistType,
 	comment?: string,
+	groups?: number[],
 	enabled = true,
 ): Promise<AddAdlistResponse> {
 	return apiV1Fetch<AddAdlistResponse>('/adlists/', {
 		method: 'POST',
-		body: JSON.stringify({ address, type, comment: comment || undefined, enabled }),
+		body: JSON.stringify({
+			address,
+			type,
+			comment: comment || undefined,
+			groups: groups && groups.length > 0 ? groups : undefined,
+			enabled,
+		}),
 	});
 }
 

--- a/frontend/src/lib/api/domainrules.ts
+++ b/frontend/src/lib/api/domainrules.ts
@@ -17,10 +17,15 @@ export async function addDomainRule(
 	kind: RuleKind,
 	domain: string | string[],
 	comment?: string,
+	groups?: number[],
 ): Promise<AddDomainRuleResponse> {
 	return apiV1Fetch<AddDomainRuleResponse>(`/domain/type/${type}/kind/${kind}`, {
 		method: 'POST',
-		body: JSON.stringify({ domain, comment: comment || undefined }),
+		body: JSON.stringify({
+			domain,
+			comment: comment || undefined,
+			groups: groups && groups.length > 0 ? groups : undefined,
+		}),
 	});
 }
 

--- a/frontend/src/lib/api/groups.ts
+++ b/frontend/src/lib/api/groups.ts
@@ -1,0 +1,37 @@
+import { apiV1Fetch } from './client';
+import type {
+	ListGroupsResponse,
+	GroupMutateResponse,
+	RemoveGroupResponse,
+} from '@/types/group';
+
+export async function listGroups(): Promise<ListGroupsResponse> {
+	return apiV1Fetch<ListGroupsResponse>('/groups/');
+}
+
+export async function addGroup(
+	name: string,
+	description?: string,
+	enabled = true,
+): Promise<GroupMutateResponse> {
+	return apiV1Fetch<GroupMutateResponse>('/groups/', {
+		method: 'POST',
+		body: JSON.stringify({ name, description: description || undefined, enabled }),
+	});
+}
+
+export async function updateGroup(
+	name: string,
+	patch: { description?: string | null; enabled?: boolean },
+): Promise<GroupMutateResponse> {
+	return apiV1Fetch<GroupMutateResponse>(`/groups/${encodeURIComponent(name)}`, {
+		method: 'PUT',
+		body: JSON.stringify(patch),
+	});
+}
+
+export async function removeGroup(name: string): Promise<RemoveGroupResponse> {
+	return apiV1Fetch<RemoveGroupResponse>(`/groups/${encodeURIComponent(name)}`, {
+		method: 'DELETE',
+	});
+}

--- a/frontend/src/lib/api/piholeClients.ts
+++ b/frontend/src/lib/api/piholeClients.ts
@@ -1,0 +1,24 @@
+import { apiV1Fetch } from './client';
+import type {
+	ListClientsResponse,
+	ClientMutateResponse,
+	RemoveClientResponse,
+} from '@/types/pihole_client';
+
+export async function listPiholeClients(): Promise<ListClientsResponse> {
+	return apiV1Fetch<ListClientsResponse>('/clients/');
+}
+
+export async function updatePiholeClient(
+	id: number,
+	patch: { groups: number[]; comment?: string | null },
+): Promise<ClientMutateResponse> {
+	return apiV1Fetch<ClientMutateResponse>(`/clients/${id}`, {
+		method: 'PUT',
+		body: JSON.stringify(patch),
+	});
+}
+
+export async function removePiholeClient(id: number): Promise<RemoveClientResponse> {
+	return apiV1Fetch<RemoveClientResponse>(`/clients/${id}`, { method: 'DELETE' });
+}

--- a/frontend/src/pages/Adlists.module.scss
+++ b/frontend/src/pages/Adlists.module.scss
@@ -375,6 +375,29 @@
 
 .actionsCell { text-align: right; white-space: nowrap; }
 
+.actionBtns {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+}
+
+.editGroupsBtn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	background: transparent;
+	border: none;
+	border-radius: var(--border-radius);
+	color: var(--accent-primary);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover { background: color-mix(in oklab, var(--accent-primary) 10%, transparent); }
+	&:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
 .removeBtn {
 	display: inline-flex;
 	align-items: center;
@@ -558,6 +581,31 @@
 	cursor: pointer;
 	&:hover:not(:disabled) { background: var(--btn-primary-bg-hover); }
 	&:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+// Group checkboxes in add/edit-groups dialogs
+
+.groupCheckboxList {
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+	max-height: 160px;
+	overflow-y: auto;
+	padding: 0.4rem;
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+}
+
+.groupCheckboxItem {
+	display: flex;
+	align-items: center;
+	gap: 0.45rem;
+	font-size: 0.85rem;
+	color: var(--text-primary);
+	cursor: pointer;
+	padding: 0.15rem 0.2rem;
+
+	input[type='checkbox'] { width: 0.95rem; height: 0.95rem; cursor: pointer; }
 }
 
 @include respond-max($breakpoint-md) {

--- a/frontend/src/pages/Adlists.tsx
+++ b/frontend/src/pages/Adlists.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import {
+	Pencil,
 	Plus,
 	Trash2,
 	RefreshCw,
@@ -18,12 +19,14 @@ import {
 	removeAdlist,
 	rebuildGravity,
 } from '@/lib/api/adlists';
+import { listGroups } from '@/lib/api/groups';
 import type {
 	ConsolidatedAdlist,
 	AdlistType,
 	ListAdlistsResponse,
 	GravityRebuildResponse,
 } from '@/types/adlist';
+import type { Group } from '@/types/group';
 import { formatCount } from '@/utils/formatters';
 import styles from './Adlists.module.scss';
 
@@ -71,9 +74,10 @@ type AddForm = {
 	address: string;
 	type: AdlistType;
 	comment: string;
+	groups: number[];
 };
 
-const DEFAULT_ADD_FORM: AddForm = { address: '', type: 'block', comment: '' };
+const DEFAULT_ADD_FORM: AddForm = { address: '', type: 'block', comment: '', groups: [] };
 
 type GravityResult = {
 	response: GravityRebuildResponse;
@@ -85,12 +89,19 @@ export function Adlists() {
 	const [error, setError] = useState<string | null>(null);
 	const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
 	const [gravityStale, setGravityStale] = useState(false);
+	const [availableGroups, setAvailableGroups] = useState<Group[]>([]);
 
 	// Add dialog
 	const [addOpen, setAddOpen] = useState(false);
 	const [addForm, setAddForm] = useState<AddForm>(DEFAULT_ADD_FORM);
 	const [addSubmitting, setAddSubmitting] = useState(false);
 	const [addError, setAddError] = useState<string | null>(null);
+
+	// Edit groups dialog
+	const [editGroupsAdlist, setEditGroupsAdlist] = useState<ConsolidatedAdlist | null>(null);
+	const [editGroupsList, setEditGroupsList] = useState<number[]>([]);
+	const [editGroupsSubmitting, setEditGroupsSubmitting] = useState(false);
+	const [editGroupsError, setEditGroupsError] = useState<string | null>(null);
 
 	// Remove confirm
 	const [removeConfirm, setRemoveConfirm] = useState<number | null>(null);
@@ -121,7 +132,45 @@ export function Adlists() {
 		load();
 	}, [load]);
 
+	useEffect(() => {
+		listGroups()
+			.then((resp) => {
+				const map = new Map<number, Group>();
+				for (const nr of Object.values(resp.nodes)) {
+					for (const g of nr.groups) {
+						if (!map.has(g.id)) map.set(g.id, g);
+					}
+				}
+				setAvailableGroups(Array.from(map.values()).sort((a, b) => a.id - b.id));
+			})
+			.catch(() => { /* non-fatal — group pickers stay empty */ });
+	}, []);
+
 	const filtered = adlists.filter((a) => typeFilter === 'all' || a.type === typeFilter);
+
+	const groupNameById = new Map(availableGroups.map((g) => [g.id, g.name]));
+
+	// Edit groups
+	const openEditGroups = (adlist: ConsolidatedAdlist) => {
+		setEditGroupsAdlist(adlist);
+		setEditGroupsList([...adlist.groups]);
+		setEditGroupsError(null);
+	};
+
+	const handleSaveGroups = async () => {
+		if (!editGroupsAdlist) return;
+		setEditGroupsSubmitting(true);
+		setEditGroupsError(null);
+		try {
+			await updateAdlist(editGroupsAdlist.id, { groups: editGroupsList });
+			setEditGroupsAdlist(null);
+			await load();
+		} catch (e) {
+			setEditGroupsError(e instanceof Error ? e.message : 'Failed to update groups');
+		} finally {
+			setEditGroupsSubmitting(false);
+		}
+	};
 
 	// Add
 	const handleAdd = async () => {
@@ -132,7 +181,12 @@ export function Adlists() {
 		setAddSubmitting(true);
 		setAddError(null);
 		try {
-			await addAdlist(addForm.address.trim(), addForm.type, addForm.comment.trim() || undefined);
+			await addAdlist(
+				addForm.address.trim(),
+				addForm.type,
+				addForm.comment.trim() || undefined,
+				addForm.groups.length > 0 ? addForm.groups : undefined,
+			);
 			setAddOpen(false);
 			setAddForm(DEFAULT_ADD_FORM);
 			setGravityStale(true);
@@ -373,9 +427,9 @@ export function Adlists() {
 												<span className={styles.noGroups}>—</span>
 											) : (
 												<div className={styles.groupBadges}>
-													{adlist.groups.map((g) => (
-														<span key={g} className={styles.groupBadge}>
-															Group {g}
+													{adlist.groups.map((gid) => (
+														<span key={gid} className={styles.groupBadge}>
+															{groupNameById.get(gid) ?? `Group ${gid}`}
 														</span>
 													))}
 												</div>
@@ -419,14 +473,24 @@ export function Adlists() {
 													</button>
 												</span>
 											) : (
-												<button
-													className={styles.removeBtn}
-													onClick={() => setRemoveConfirm(adlist.id)}
-													disabled={removing === adlist.id}
-													aria-label='Remove adlist'
-												>
-													<Trash2 size={14} />
-												</button>
+												<span className={styles.actionBtns}>
+													<button
+														className={styles.editGroupsBtn}
+														onClick={() => openEditGroups(adlist)}
+														aria-label='Assign groups'
+														title='Assign groups'
+													>
+														<Pencil size={14} />
+													</button>
+													<button
+														className={styles.removeBtn}
+														onClick={() => setRemoveConfirm(adlist.id)}
+														disabled={removing === adlist.id}
+														aria-label='Remove adlist'
+													>
+														<Trash2 size={14} />
+													</button>
+												</span>
 											)}
 										</td>
 									</tr>
@@ -498,6 +562,34 @@ export function Adlists() {
 							/>
 						</div>
 
+						{availableGroups.length > 0 && (
+							<div className={styles.formGroup}>
+								<span className={styles.label}>
+									Groups <span className={styles.optional}>(optional)</span>
+								</span>
+								<div className={styles.groupCheckboxList}>
+									{availableGroups.map((g) => (
+										<label key={g.id} className={styles.groupCheckboxItem}>
+											<input
+												type='checkbox'
+												checked={addForm.groups.includes(g.id)}
+												onChange={() =>
+													setAddForm((f) => ({
+														...f,
+														groups: f.groups.includes(g.id)
+															? f.groups.filter((x) => x !== g.id)
+															: [...f.groups, g.id],
+													}))
+												}
+												disabled={addSubmitting}
+											/>
+											{g.name}
+										</label>
+									))}
+								</div>
+							</div>
+						)}
+
 						<div className={styles.dialogFooter}>
 							<Dialog.Close className={styles.cancelBtn} disabled={addSubmitting}>
 								Cancel
@@ -508,6 +600,67 @@ export function Adlists() {
 								disabled={addSubmitting || !addForm.address.trim()}
 							>
 								{addSubmitting ? 'Adding…' : 'Add adlist'}
+							</button>
+						</div>
+					</Dialog.Content>
+				</Dialog.Portal>
+			</Dialog.Root>
+
+			{/* Edit groups dialog */}
+			<Dialog.Root
+				open={editGroupsAdlist !== null}
+				onOpenChange={(next) => { if (!next) { setEditGroupsAdlist(null); setEditGroupsError(null); } }}
+			>
+				<Dialog.Portal>
+					<Dialog.Overlay className={styles.dialogOverlay} />
+					<Dialog.Content className={styles.dialog} aria-describedby={undefined}>
+						<div className={styles.dialogHeader}>
+							<Dialog.Title className={styles.dialogTitle}>
+								Assign groups — {editGroupsAdlist?.address}
+							</Dialog.Title>
+							<Dialog.Close className={styles.dialogClose} aria-label='Close'>
+								<X size={16} />
+							</Dialog.Close>
+						</div>
+
+						{editGroupsError && <div className={styles.dialogError}>{editGroupsError}</div>}
+
+						<div className={styles.formGroup}>
+							{availableGroups.length === 0 ? (
+								<p className={styles.optional}>No groups available.</p>
+							) : (
+								<div className={styles.groupCheckboxList}>
+									{availableGroups.map((g) => (
+										<label key={g.id} className={styles.groupCheckboxItem}>
+											<input
+												type='checkbox'
+												checked={editGroupsList.includes(g.id)}
+												onChange={() =>
+													setEditGroupsList((prev) =>
+														prev.includes(g.id)
+															? prev.filter((x) => x !== g.id)
+															: [...prev, g.id],
+													)
+												}
+												disabled={editGroupsSubmitting}
+											/>
+											{g.name}{g.description ? ` — ${g.description}` : ''}
+										</label>
+									))}
+								</div>
+							)}
+						</div>
+
+						<div className={styles.dialogFooter}>
+							<Dialog.Close className={styles.cancelBtn} disabled={editGroupsSubmitting}>
+								Cancel
+							</Dialog.Close>
+							<button
+								className={styles.submitBtn}
+								onClick={handleSaveGroups}
+								disabled={editGroupsSubmitting}
+							>
+								{editGroupsSubmitting ? 'Saving…' : 'Save'}
 							</button>
 						</div>
 					</Dialog.Content>

--- a/frontend/src/pages/Clients.module.scss
+++ b/frontend/src/pages/Clients.module.scss
@@ -1,0 +1,427 @@
+@use '@/styles/mixins' as *;
+@use '@/styles/variables' as *;
+
+.page {
+	padding: 1.25rem;
+	max-width: 72rem;
+	margin-inline: auto;
+}
+
+// ── Section layout ──────────────────────────────────────────────
+
+.section {
+	margin-bottom: 2rem;
+}
+
+.sectionHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	margin-bottom: 0.75rem;
+}
+
+.sectionTitle {
+	font-size: 1.1rem;
+	font-weight: 700;
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.headerActions {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+// ── Shared table ─────────────────────────────────────────────────
+
+.tableWrap {
+	overflow-x: auto;
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+}
+
+.table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.85rem;
+
+	thead th {
+		text-align: left;
+		padding: 0.6rem 0.9rem;
+		background: var(--bg-header);
+		font-weight: 600;
+		color: var(--text-primary);
+		border-bottom: 1px solid var(--border-primary);
+		white-space: nowrap;
+	}
+
+	tbody tr {
+		border-bottom: 1px solid var(--border-primary);
+		&:last-child { border-bottom: none; }
+		&:nth-child(even) { background: var(--bg-table-stripe); }
+	}
+
+	td {
+		padding: 0.6rem 0.9rem;
+		color: var(--text-primary);
+		vertical-align: middle;
+	}
+}
+
+.actionCell {
+	width: 1%;
+	white-space: nowrap;
+	text-align: right;
+}
+
+.actionRow {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	justify-content: flex-end;
+}
+
+// ── Badges ───────────────────────────────────────────────────────
+
+.enabledBadge {
+	display: inline-block;
+	padding: 0.15rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.75rem;
+	font-weight: 600;
+
+	&[data-enabled='true'] {
+		background: color-mix(in oklab, var(--accent-success) 15%, transparent);
+		color: var(--accent-success);
+	}
+
+	&[data-enabled='false'] {
+		background: color-mix(in oklab, var(--text-secondary) 15%, transparent);
+		color: var(--text-secondary);
+	}
+}
+
+.groupBadges {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.3rem;
+}
+
+.groupBadge {
+	display: inline-block;
+	padding: 0.15rem 0.5rem;
+	background: color-mix(in oklab, var(--accent-primary) 12%, transparent);
+	color: var(--accent-primary);
+	border-radius: 999px;
+	font-size: 0.75rem;
+	font-weight: 500;
+}
+
+.noGroups {
+	color: var(--text-secondary);
+}
+
+// ── Buttons ──────────────────────────────────────────────────────
+
+.refreshBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.35rem 0.75rem;
+	font-size: 0.82rem;
+	font-weight: 500;
+	color: var(--btn-surface-text);
+	background: var(--btn-surface-bg);
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) { background: var(--btn-surface-bg-hover); }
+	&:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+.addBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.35rem 0.75rem;
+	font-size: 0.82rem;
+	font-weight: 500;
+	color: var(--btn-primary-text);
+	background: var(--btn-primary-bg);
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) { background: var(--btn-primary-bg-hover); }
+	&:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+.editBtn,
+.removeBtn {
+	display: inline-flex;
+	align-items: center;
+	padding: 0.3rem;
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+}
+
+.editBtn {
+	background: transparent;
+	color: var(--accent-primary);
+	&:hover { background: color-mix(in oklab, var(--accent-primary) 10%, transparent); }
+	&:disabled { opacity: 0.4; cursor: not-allowed; }
+}
+
+.removeBtn {
+	background: transparent;
+	color: var(--accent-danger);
+	&:hover { background: color-mix(in oklab, var(--accent-danger) 10%, transparent); }
+	&:disabled { opacity: 0.4; cursor: not-allowed; }
+}
+
+// ── Confirm inline ───────────────────────────────────────────────
+
+.confirmRow {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+}
+
+.confirmText {
+	font-size: 0.8rem;
+	color: var(--text-secondary);
+}
+
+.confirmYesBtn {
+	padding: 0.2rem 0.5rem;
+	font-size: 0.78rem;
+	font-weight: 600;
+	color: var(--btn-danger-text);
+	background: var(--btn-danger-bg);
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	&:hover { background: var(--btn-danger-bg-hover); }
+	&:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+.confirmNoBtn {
+	padding: 0.2rem 0.5rem;
+	font-size: 0.78rem;
+	font-weight: 600;
+	color: var(--btn-cancel-text);
+	background: var(--btn-cancel-bg);
+	border: 1px solid var(--btn-cancel-border);
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	&:hover { background: var(--btn-cancel-bg-hover); }
+	&:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+// ── Status banners ───────────────────────────────────────────────
+
+.error {
+	margin-bottom: 0.75rem;
+	padding: 0.6rem 0.9rem;
+	background: var(--error-bg);
+	color: var(--error-text);
+	border-radius: var(--border-radius);
+	font-size: 0.85rem;
+}
+
+.loadingState,
+.emptyState {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.5rem;
+	padding: 2rem;
+	color: var(--text-secondary);
+	font-size: 0.9rem;
+}
+
+.tableInfo {
+	font-size: 0.8rem;
+	color: var(--text-secondary);
+	margin-bottom: 0.4rem;
+}
+
+// ── Dialog ───────────────────────────────────────────────────────
+
+.overlay {
+	position: fixed;
+	inset: 0;
+	background: var(--bg-overlay);
+	z-index: 50;
+}
+
+.dialog {
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	background: var(--bg-card);
+	border: 1px solid var(--border-primary);
+	border-radius: var(--card-radius);
+	padding: 1.5rem;
+	width: min(480px, 95vw);
+	max-height: 90vh;
+	overflow-y: auto;
+	z-index: 51;
+	box-shadow: var(--card-shadow);
+}
+
+.dialogTitle {
+	font-size: 1.05rem;
+	font-weight: 700;
+	color: var(--text-primary);
+	margin: 0 0 1.1rem;
+}
+
+.dialogClose {
+	position: absolute;
+	top: 0.75rem;
+	right: 0.75rem;
+	background: transparent;
+	border: none;
+	color: var(--text-secondary);
+	cursor: pointer;
+	padding: 0.25rem;
+	border-radius: var(--border-radius);
+	display: flex;
+	align-items: center;
+	&:hover { color: var(--text-primary); }
+}
+
+.dialogActions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.6rem;
+	margin-top: 1.2rem;
+}
+
+.dialogError {
+	margin-top: 0.6rem;
+	padding: 0.5rem 0.75rem;
+	background: var(--error-bg);
+	color: var(--error-text);
+	border-radius: var(--border-radius);
+	font-size: 0.82rem;
+}
+
+.cancelBtn {
+	padding: 0.45rem 1rem;
+	font-size: 0.85rem;
+	font-weight: 500;
+	color: var(--btn-cancel-text);
+	background: var(--btn-cancel-bg);
+	border: 1px solid var(--btn-cancel-border);
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	&:hover:not(:disabled) { background: var(--btn-cancel-bg-hover); }
+	&:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+.submitBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.45rem 1rem;
+	font-size: 0.85rem;
+	font-weight: 500;
+	color: var(--btn-primary-text);
+	background: var(--btn-primary-bg);
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	&:hover:not(:disabled) { background: var(--btn-primary-bg-hover); }
+	&:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+// ── Form fields ──────────────────────────────────────────────────
+
+.field {
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+	margin-bottom: 0.9rem;
+}
+
+.fieldLabel {
+	font-size: 0.85rem;
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.fieldHint {
+	font-weight: 400;
+	color: var(--text-secondary);
+	margin-left: 0.35rem;
+}
+
+.input {
+	padding: 0.45rem 0.6rem;
+	font-size: 0.85rem;
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+	background: var(--bg-page);
+	color: var(--text-primary);
+	width: 100%;
+	box-sizing: border-box;
+	&:focus { outline: 2px solid var(--accent-primary); outline-offset: -1px; }
+	&:disabled { opacity: 0.6; }
+}
+
+.checkboxField {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: 0.85rem;
+	color: var(--text-primary);
+	cursor: pointer;
+
+	input[type='checkbox'] { width: 1rem; height: 1rem; cursor: pointer; }
+}
+
+// ── Group checkboxes in update-client dialog ─────────────────────
+
+.groupCheckboxList {
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+	max-height: 180px;
+	overflow-y: auto;
+	padding: 0.4rem;
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+}
+
+.groupCheckboxItem {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: 0.85rem;
+	color: var(--text-primary);
+	cursor: pointer;
+	padding: 0.2rem 0.25rem;
+
+	input[type='checkbox'] { width: 1rem; height: 1rem; cursor: pointer; }
+}
+
+// ── Spinning icon ─────────────────────────────────────────────────
+
+.spin {
+	animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+	to { transform: rotate(360deg); }
+}

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -407,7 +407,7 @@ function ClientsPanel({ groups }: ClientsPanelProps) {
 		setEditError(null);
 		setEditSubmitting(true);
 		try {
-			await updatePiholeClient(editClient.id, { groups: editGroups });
+			await updatePiholeClient(editClient.id, { groups: editGroups, comment: editClient.comment });
 			setEditClient(null);
 			await fetchClients();
 		} catch (err) {

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -1,0 +1,637 @@
+import { useState, useEffect, useCallback } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Plus, Pencil, Trash2, RefreshCw, X } from 'lucide-react';
+import { listGroups, addGroup, updateGroup, removeGroup } from '@/lib/api/groups';
+import { listPiholeClients, updatePiholeClient, removePiholeClient } from '@/lib/api/piholeClients';
+import type { Group, ListGroupsResponse } from '@/types/group';
+import type { PiholeClient, ListClientsResponse } from '@/types/pihole_client';
+import styles from './Clients.module.scss';
+
+// ── Consolidation ────────────────────────────────────────────────
+
+function consolidateGroups(resp: ListGroupsResponse): Group[] {
+	const map = new Map<number, Group>();
+	for (const nr of Object.values(resp.nodes)) {
+		for (const g of nr.groups) {
+			if (!map.has(g.id)) map.set(g.id, g);
+		}
+	}
+	return Array.from(map.values()).sort((a, b) => a.id - b.id);
+}
+
+function consolidateClients(resp: ListClientsResponse): PiholeClient[] {
+	const map = new Map<number, PiholeClient>();
+	for (const nr of Object.values(resp.nodes)) {
+		for (const c of nr.clients) {
+			if (!map.has(c.id)) map.set(c.id, c);
+		}
+	}
+	return Array.from(map.values()).sort((a, b) => a.ip.localeCompare(b.ip));
+}
+
+// ── Types ─────────────────────────────────────────────────────────
+
+type AddGroupForm = { name: string; description: string; enabled: boolean };
+type EditGroupForm = { description: string; enabled: boolean };
+
+const DEFAULT_ADD_GROUP: AddGroupForm = { name: '', description: '', enabled: true };
+
+// ── Groups panel ─────────────────────────────────────────────────
+
+type GroupsPanelProps = {
+	groups: Group[];
+	loading: boolean;
+	error: string | null;
+	onRefresh: () => void;
+};
+
+function GroupsPanel({ groups, loading, error, onRefresh }: GroupsPanelProps) {
+	const [addOpen, setAddOpen] = useState(false);
+	const [addForm, setAddForm] = useState<AddGroupForm>(DEFAULT_ADD_GROUP);
+	const [addSubmitting, setAddSubmitting] = useState(false);
+	const [addError, setAddError] = useState<string | null>(null);
+
+	const [editGroup, setEditGroup] = useState<Group | null>(null);
+	const [editForm, setEditForm] = useState<EditGroupForm>({ description: '', enabled: true });
+	const [editSubmitting, setEditSubmitting] = useState(false);
+	const [editError, setEditError] = useState<string | null>(null);
+
+	const [removeConfirm, setRemoveConfirm] = useState<string | null>(null);
+	const [removing, setRemoving] = useState<string | null>(null);
+	const [removeError, setRemoveError] = useState<string | null>(null);
+
+	async function handleAdd() {
+		setAddError(null);
+		if (!addForm.name.trim()) { setAddError('Name is required'); return; }
+		setAddSubmitting(true);
+		try {
+			await addGroup(addForm.name.trim(), addForm.description.trim() || undefined, addForm.enabled);
+			setAddOpen(false);
+			setAddForm(DEFAULT_ADD_GROUP);
+			onRefresh();
+		} catch (err) {
+			setAddError(err instanceof Error ? err.message : 'Failed to add group');
+		} finally {
+			setAddSubmitting(false);
+		}
+	}
+
+	function openEdit(g: Group) {
+		setEditGroup(g);
+		setEditForm({ description: g.description ?? '', enabled: g.enabled });
+		setEditError(null);
+	}
+
+	async function handleEdit() {
+		if (!editGroup) return;
+		setEditError(null);
+		setEditSubmitting(true);
+		try {
+			await updateGroup(editGroup.name, {
+				description: editForm.description.trim() || null,
+				enabled: editForm.enabled,
+			});
+			setEditGroup(null);
+			onRefresh();
+		} catch (err) {
+			setEditError(err instanceof Error ? err.message : 'Failed to update group');
+		} finally {
+			setEditSubmitting(false);
+		}
+	}
+
+	async function handleRemove(name: string) {
+		setRemoveError(null);
+		setRemoving(name);
+		try {
+			await removeGroup(name);
+			setRemoveConfirm(null);
+			onRefresh();
+		} catch (err) {
+			setRemoveError(err instanceof Error ? err.message : 'Failed to remove group');
+		} finally {
+			setRemoving(null);
+		}
+	}
+
+	return (
+		<div className={styles.section}>
+			<div className={styles.sectionHeader}>
+				<h2 className={styles.sectionTitle}>Groups</h2>
+				<div className={styles.headerActions}>
+					<button
+						type='button'
+						className={styles.refreshBtn}
+						onClick={onRefresh}
+						disabled={loading}
+						aria-label='Refresh groups'
+					>
+						<RefreshCw size={15} className={loading ? styles.spin : undefined} />
+					</button>
+
+					<Dialog.Root
+						open={addOpen}
+						onOpenChange={(next) => {
+							setAddOpen(next);
+							if (!next) { setAddForm(DEFAULT_ADD_GROUP); setAddError(null); }
+						}}
+					>
+						<Dialog.Trigger asChild>
+							<button type='button' className={styles.addBtn}>
+								<Plus size={15} /> Add group
+							</button>
+						</Dialog.Trigger>
+						<Dialog.Portal>
+							<Dialog.Overlay className={styles.overlay} />
+							<Dialog.Content className={styles.dialog}>
+								<Dialog.Title className={styles.dialogTitle}>Add group</Dialog.Title>
+								<div className={styles.field}>
+									<label htmlFor='add-group-name' className={styles.fieldLabel}>Name</label>
+									<input
+										id='add-group-name'
+										type='text'
+										className={styles.input}
+										placeholder='e.g. Kids Devices'
+										value={addForm.name}
+										onChange={(e) => setAddForm((f) => ({ ...f, name: e.target.value }))}
+										disabled={addSubmitting}
+									/>
+								</div>
+								<div className={styles.field}>
+									<label htmlFor='add-group-desc' className={styles.fieldLabel}>
+										Description <span className={styles.fieldHint}>(optional)</span>
+									</label>
+									<input
+										id='add-group-desc'
+										type='text'
+										className={styles.input}
+										placeholder='Short description'
+										value={addForm.description}
+										onChange={(e) => setAddForm((f) => ({ ...f, description: e.target.value }))}
+										disabled={addSubmitting}
+									/>
+								</div>
+								<div className={styles.field}>
+									<label className={styles.checkboxField}>
+										<input
+											type='checkbox'
+											checked={addForm.enabled}
+											onChange={(e) => setAddForm((f) => ({ ...f, enabled: e.target.checked }))}
+											disabled={addSubmitting}
+										/>
+										Enabled
+									</label>
+								</div>
+								{addError && <p className={styles.dialogError}>{addError}</p>}
+								<div className={styles.dialogActions}>
+									<Dialog.Close asChild>
+										<button type='button' className={styles.cancelBtn} disabled={addSubmitting}>Cancel</button>
+									</Dialog.Close>
+									<button
+										type='button'
+										className={styles.submitBtn}
+										onClick={handleAdd}
+										disabled={addSubmitting || !addForm.name.trim()}
+										aria-busy={addSubmitting}
+									>
+										{addSubmitting ? <RefreshCw size={14} className={styles.spin} /> : null}
+										Add
+									</button>
+								</div>
+								<Dialog.Close asChild>
+									<button className={styles.dialogClose} aria-label='Close'><X size={18} /></button>
+								</Dialog.Close>
+							</Dialog.Content>
+						</Dialog.Portal>
+					</Dialog.Root>
+				</div>
+			</div>
+
+			{error && <div className={styles.error}>{error}</div>}
+			{removeError && <div className={styles.error}>{removeError}</div>}
+
+			{loading && groups.length === 0 && (
+				<div className={styles.loadingState}><RefreshCw size={18} className={styles.spin} /> Loading…</div>
+			)}
+			{!loading && !error && groups.length === 0 && (
+				<div className={styles.emptyState}>No groups configured.</div>
+			)}
+
+			{groups.length > 0 && (
+				<>
+					<div className={styles.tableInfo}>{groups.length} {groups.length === 1 ? 'group' : 'groups'}</div>
+					<div className={styles.tableWrap}>
+						<table className={styles.table}>
+							<thead>
+								<tr>
+									<th>ID</th>
+									<th>Name</th>
+									<th>Description</th>
+									<th>Status</th>
+									<th aria-label='Actions' />
+								</tr>
+							</thead>
+							<tbody>
+								{groups.map((g) => {
+									const isDefault = g.id === 0;
+									const confirming = removeConfirm === g.name;
+									const isRemoving = removing === g.name;
+									return (
+										<tr key={g.id}>
+											<td>{g.id}</td>
+											<td>{g.name}</td>
+											<td>{g.description ?? '—'}</td>
+											<td>
+												<span className={styles.enabledBadge} data-enabled={String(g.enabled)}>
+													{g.enabled ? 'Enabled' : 'Disabled'}
+												</span>
+											</td>
+											<td className={styles.actionCell}>
+												{confirming ? (
+													<div className={styles.confirmRow}>
+														<span className={styles.confirmText}>Remove?</span>
+														<button
+															type='button'
+															className={styles.confirmYesBtn}
+															onClick={() => handleRemove(g.name)}
+															disabled={isRemoving}
+														>
+															{isRemoving ? <RefreshCw size={12} className={styles.spin} /> : 'Yes'}
+														</button>
+														<button
+															type='button'
+															className={styles.confirmNoBtn}
+															onClick={() => { setRemoveConfirm(null); setRemoveError(null); }}
+															disabled={isRemoving}
+														>No</button>
+													</div>
+												) : (
+													<div className={styles.actionRow}>
+														<button
+															type='button'
+															className={styles.editBtn}
+															onClick={() => openEdit(g)}
+															aria-label={`Edit ${g.name}`}
+														>
+															<Pencil size={14} />
+														</button>
+														{!isDefault && (
+															<button
+																type='button'
+																className={styles.removeBtn}
+																onClick={() => setRemoveConfirm(g.name)}
+																aria-label={`Remove ${g.name}`}
+															>
+																<Trash2 size={14} />
+															</button>
+														)}
+													</div>
+												)}
+											</td>
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				</>
+			)}
+
+			{/* Edit dialog */}
+			<Dialog.Root
+				open={editGroup !== null}
+				onOpenChange={(next) => { if (!next) { setEditGroup(null); setEditError(null); } }}
+			>
+				<Dialog.Portal>
+					<Dialog.Overlay className={styles.overlay} />
+					<Dialog.Content className={styles.dialog}>
+						<Dialog.Title className={styles.dialogTitle}>Edit group — {editGroup?.name}</Dialog.Title>
+						<div className={styles.field}>
+							<label htmlFor='edit-group-desc' className={styles.fieldLabel}>
+								Description <span className={styles.fieldHint}>(optional)</span>
+							</label>
+							<input
+								id='edit-group-desc'
+								type='text'
+								className={styles.input}
+								placeholder='Short description'
+								value={editForm.description}
+								onChange={(e) => setEditForm((f) => ({ ...f, description: e.target.value }))}
+								disabled={editSubmitting}
+							/>
+						</div>
+						<div className={styles.field}>
+							<label className={styles.checkboxField}>
+								<input
+									type='checkbox'
+									checked={editForm.enabled}
+									onChange={(e) => setEditForm((f) => ({ ...f, enabled: e.target.checked }))}
+									disabled={editSubmitting}
+								/>
+								Enabled
+							</label>
+						</div>
+						{editError && <p className={styles.dialogError}>{editError}</p>}
+						<div className={styles.dialogActions}>
+							<Dialog.Close asChild>
+								<button type='button' className={styles.cancelBtn} disabled={editSubmitting}>Cancel</button>
+							</Dialog.Close>
+							<button
+								type='button'
+								className={styles.submitBtn}
+								onClick={handleEdit}
+								disabled={editSubmitting}
+								aria-busy={editSubmitting}
+							>
+								{editSubmitting ? <RefreshCw size={14} className={styles.spin} /> : null}
+								Save
+							</button>
+						</div>
+						<Dialog.Close asChild>
+							<button className={styles.dialogClose} aria-label='Close'><X size={18} /></button>
+						</Dialog.Close>
+					</Dialog.Content>
+				</Dialog.Portal>
+			</Dialog.Root>
+		</div>
+	);
+}
+
+// ── Clients panel ─────────────────────────────────────────────────
+
+type ClientsPanelProps = {
+	groups: Group[];
+};
+
+function ClientsPanel({ groups }: ClientsPanelProps) {
+	const [clients, setClients] = useState<PiholeClient[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const [editClient, setEditClient] = useState<PiholeClient | null>(null);
+	const [editGroups, setEditGroups] = useState<number[]>([]);
+	const [editSubmitting, setEditSubmitting] = useState(false);
+	const [editError, setEditError] = useState<string | null>(null);
+
+	const [removeConfirm, setRemoveConfirm] = useState<number | null>(null);
+	const [removing, setRemoving] = useState<number | null>(null);
+	const [removeError, setRemoveError] = useState<string | null>(null);
+
+	const fetchClients = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const resp = await listPiholeClients();
+			setClients(consolidateClients(resp));
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to load clients');
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => { fetchClients(); }, [fetchClients]);
+
+	function openEdit(c: PiholeClient) {
+		setEditClient(c);
+		setEditGroups([...c.groups]);
+		setEditError(null);
+	}
+
+	function toggleGroup(id: number) {
+		setEditGroups((prev) => prev.includes(id) ? prev.filter((g) => g !== id) : [...prev, id]);
+	}
+
+	async function handleEditGroups() {
+		if (!editClient) return;
+		setEditError(null);
+		setEditSubmitting(true);
+		try {
+			await updatePiholeClient(editClient.id, { groups: editGroups });
+			setEditClient(null);
+			await fetchClients();
+		} catch (err) {
+			setEditError(err instanceof Error ? err.message : 'Failed to update client');
+		} finally {
+			setEditSubmitting(false);
+		}
+	}
+
+	async function handleRemove(id: number) {
+		setRemoveError(null);
+		setRemoving(id);
+		try {
+			await removePiholeClient(id);
+			setRemoveConfirm(null);
+			await fetchClients();
+		} catch (err) {
+			setRemoveError(err instanceof Error ? err.message : 'Failed to remove client');
+		} finally {
+			setRemoving(null);
+		}
+	}
+
+	const groupNameById = new Map(groups.map((g) => [g.id, g.name]));
+
+	return (
+		<div className={styles.section}>
+			<div className={styles.sectionHeader}>
+				<h2 className={styles.sectionTitle}>Clients</h2>
+				<div className={styles.headerActions}>
+					<button
+						type='button'
+						className={styles.refreshBtn}
+						onClick={fetchClients}
+						disabled={loading}
+						aria-label='Refresh clients'
+					>
+						<RefreshCw size={15} className={loading ? styles.spin : undefined} />
+					</button>
+				</div>
+			</div>
+
+			{error && <div className={styles.error}>{error}</div>}
+			{removeError && <div className={styles.error}>{removeError}</div>}
+
+			{loading && clients.length === 0 && (
+				<div className={styles.loadingState}><RefreshCw size={18} className={styles.spin} /> Loading…</div>
+			)}
+			{!loading && !error && clients.length === 0 && (
+				<div className={styles.emptyState}>No clients configured.</div>
+			)}
+
+			{clients.length > 0 && (
+				<>
+					<div className={styles.tableInfo}>{clients.length} {clients.length === 1 ? 'client' : 'clients'}</div>
+					<div className={styles.tableWrap}>
+						<table className={styles.table}>
+							<thead>
+								<tr>
+									<th>IP</th>
+									<th>Name</th>
+									<th>Groups</th>
+									<th aria-label='Actions' />
+								</tr>
+							</thead>
+							<tbody>
+								{clients.map((c) => {
+									const confirming = removeConfirm === c.id;
+									const isRemoving = removing === c.id;
+									return (
+										<tr key={c.id}>
+											<td>{c.ip}</td>
+											<td>{c.name || '—'}</td>
+											<td>
+												{c.groups.length === 0 ? (
+													<span className={styles.noGroups}>—</span>
+												) : (
+													<div className={styles.groupBadges}>
+														{c.groups.map((gid) => (
+															<span key={gid} className={styles.groupBadge}>
+																{groupNameById.get(gid) ?? `Group ${gid}`}
+															</span>
+														))}
+													</div>
+												)}
+											</td>
+											<td className={styles.actionCell}>
+												{confirming ? (
+													<div className={styles.confirmRow}>
+														<span className={styles.confirmText}>Remove?</span>
+														<button
+															type='button'
+															className={styles.confirmYesBtn}
+															onClick={() => handleRemove(c.id)}
+															disabled={isRemoving}
+														>
+															{isRemoving ? <RefreshCw size={12} className={styles.spin} /> : 'Yes'}
+														</button>
+														<button
+															type='button'
+															className={styles.confirmNoBtn}
+															onClick={() => { setRemoveConfirm(null); setRemoveError(null); }}
+															disabled={isRemoving}
+														>No</button>
+													</div>
+												) : (
+													<div className={styles.actionRow}>
+														<button
+															type='button'
+															className={styles.editBtn}
+															onClick={() => openEdit(c)}
+															aria-label={`Assign groups for ${c.ip}`}
+															title='Assign groups'
+														>
+															<Pencil size={14} />
+														</button>
+														<button
+															type='button'
+															className={styles.removeBtn}
+															onClick={() => setRemoveConfirm(c.id)}
+															aria-label={`Remove ${c.ip}`}
+														>
+															<Trash2 size={14} />
+														</button>
+													</div>
+												)}
+											</td>
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				</>
+			)}
+
+			{/* Edit client groups dialog */}
+			<Dialog.Root
+				open={editClient !== null}
+				onOpenChange={(next) => { if (!next) { setEditClient(null); setEditError(null); } }}
+			>
+				<Dialog.Portal>
+					<Dialog.Overlay className={styles.overlay} />
+					<Dialog.Content className={styles.dialog}>
+						<Dialog.Title className={styles.dialogTitle}>
+							Assign groups — {editClient?.ip}
+						</Dialog.Title>
+						<div className={styles.field}>
+							<span className={styles.fieldLabel}>Groups</span>
+							{groups.length === 0 ? (
+								<p className={styles.fieldHint}>No groups available.</p>
+							) : (
+								<div className={styles.groupCheckboxList}>
+									{groups.map((g) => (
+										<label key={g.id} className={styles.groupCheckboxItem}>
+											<input
+												type='checkbox'
+												checked={editGroups.includes(g.id)}
+												onChange={() => toggleGroup(g.id)}
+												disabled={editSubmitting}
+											/>
+											{g.name}{g.description ? ` — ${g.description}` : ''}
+										</label>
+									))}
+								</div>
+							)}
+						</div>
+						{editError && <p className={styles.dialogError}>{editError}</p>}
+						<div className={styles.dialogActions}>
+							<Dialog.Close asChild>
+								<button type='button' className={styles.cancelBtn} disabled={editSubmitting}>Cancel</button>
+							</Dialog.Close>
+							<button
+								type='button'
+								className={styles.submitBtn}
+								onClick={handleEditGroups}
+								disabled={editSubmitting}
+								aria-busy={editSubmitting}
+							>
+								{editSubmitting ? <RefreshCw size={14} className={styles.spin} /> : null}
+								Save
+							</button>
+						</div>
+						<Dialog.Close asChild>
+							<button className={styles.dialogClose} aria-label='Close'><X size={18} /></button>
+						</Dialog.Close>
+					</Dialog.Content>
+				</Dialog.Portal>
+			</Dialog.Root>
+		</div>
+	);
+}
+
+// ── Page ──────────────────────────────────────────────────────────
+
+export function Clients() {
+	const [groups, setGroups] = useState<Group[]>([]);
+	const [groupsLoading, setGroupsLoading] = useState(false);
+	const [groupsError, setGroupsError] = useState<string | null>(null);
+
+	const fetchGroups = useCallback(async () => {
+		setGroupsLoading(true);
+		setGroupsError(null);
+		try {
+			const resp = await listGroups();
+			setGroups(consolidateGroups(resp));
+		} catch (err) {
+			setGroupsError(err instanceof Error ? err.message : 'Failed to load groups');
+		} finally {
+			setGroupsLoading(false);
+		}
+	}, []);
+
+	useEffect(() => { fetchGroups(); }, [fetchGroups]);
+
+	return (
+		<div className={styles.page}>
+			<GroupsPanel
+				groups={groups}
+				loading={groupsLoading}
+				error={groupsError}
+				onRefresh={fetchGroups}
+			/>
+			<ClientsPanel groups={groups} />
+		</div>
+	);
+}

--- a/frontend/src/pages/Domains.module.scss
+++ b/frontend/src/pages/Domains.module.scss
@@ -698,6 +698,29 @@
 	}
 }
 
+.groupCheckboxList {
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+	max-height: 140px;
+	overflow-y: auto;
+	padding: 0.4rem;
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+}
+
+.groupCheckboxItem {
+	display: flex;
+	align-items: center;
+	gap: 0.45rem;
+	font-size: 0.83rem;
+	color: var(--text-primary);
+	cursor: pointer;
+	padding: 0.15rem 0.2rem;
+
+	input[type='checkbox'] { width: 0.95rem; height: 0.95rem; cursor: pointer; }
+}
+
 .spin {
 	animation: spin 0.8s linear infinite;
 }

--- a/frontend/src/pages/Domains.tsx
+++ b/frontend/src/pages/Domains.tsx
@@ -7,6 +7,7 @@ import {
 	removeDomainRule,
 	syncDomainRule,
 } from '@/lib/api/domainrules';
+import { listGroups } from '@/lib/api/groups';
 import { syncFromNode } from '@/lib/api/sync';
 import { usePiholes } from '@/providers/PiholeProvider';
 import type {
@@ -15,6 +16,7 @@ import type {
 	RuleKind,
 	ListDomainRulesResponse,
 } from '@/types/domainrule';
+import type { Group } from '@/types/group';
 import type { SyncNodeResult } from '@/types/sync';
 import styles from './Domains.module.scss';
 
@@ -59,9 +61,10 @@ type AddForm = {
 	type: RuleType;
 	kind: RuleKind;
 	comment: string;
+	groups: number[];
 };
 
-const DEFAULT_ADD_FORM: AddForm = { domains: '', type: 'deny', kind: 'exact', comment: '' };
+const DEFAULT_ADD_FORM: AddForm = { domains: '', type: 'deny', kind: 'exact', comment: '', groups: [] };
 
 export function Domains() {
 	const { piholeNodes } = usePiholes();
@@ -70,6 +73,7 @@ export function Domains() {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+	const [availableGroups, setAvailableGroups] = useState<Group[]>([]);
 
 	const [addOpen, setAddOpen] = useState(false);
 	const [addForm, setAddForm] = useState<AddForm>(DEFAULT_ADD_FORM);
@@ -107,9 +111,21 @@ export function Domains() {
 		}
 	}, []);
 
+	useEffect(() => { fetchRules(); }, [fetchRules]);
+
 	useEffect(() => {
-		fetchRules();
-	}, [fetchRules]);
+		listGroups()
+			.then((resp) => {
+				const map = new Map<number, Group>();
+				for (const nr of Object.values(resp.nodes)) {
+					for (const g of nr.groups) {
+						if (!map.has(g.id)) map.set(g.id, g);
+					}
+				}
+				setAvailableGroups(Array.from(map.values()).sort((a, b) => a.id - b.id));
+			})
+			.catch(() => { /* non-fatal — group picker stays empty */ });
+	}, []);
 
 	// Default force-sync source to first node
 	useEffect(() => {
@@ -182,6 +198,7 @@ export function Domains() {
 				addForm.kind,
 				rawDomains.length === 1 ? rawDomains[0] : rawDomains,
 				addForm.comment || undefined,
+				addForm.groups.length > 0 ? addForm.groups : undefined,
 			);
 			setAddOpen(false);
 			setAddForm(DEFAULT_ADD_FORM);
@@ -357,6 +374,35 @@ export function Domains() {
 										disabled={addSubmitting}
 									/>
 								</div>
+
+								{availableGroups.length > 0 && (
+									<div className={styles.field}>
+										<span className={styles.fieldLabel}>
+											Groups
+											<span className={styles.fieldHint}>(optional)</span>
+										</span>
+										<div className={styles.groupCheckboxList}>
+											{availableGroups.map((g) => (
+												<label key={g.id} className={styles.groupCheckboxItem}>
+													<input
+														type='checkbox'
+														checked={addForm.groups.includes(g.id)}
+														onChange={() =>
+															setAddForm((f) => ({
+																...f,
+																groups: f.groups.includes(g.id)
+																	? f.groups.filter((x) => x !== g.id)
+																	: [...f.groups, g.id],
+															}))
+														}
+														disabled={addSubmitting}
+													/>
+													{g.name}
+												</label>
+											))}
+										</div>
+									</div>
+								)}
 
 								{addError && <p className={styles.dialogError}>{addError}</p>}
 

--- a/frontend/src/types/group.ts
+++ b/frontend/src/types/group.ts
@@ -1,0 +1,56 @@
+import type { PiholeNodeRef } from './pihole';
+
+export type Group = {
+	id: number;
+	name: string;
+	description: string | null;
+	enabled: boolean;
+	dateAdded: string;
+	dateModified: string;
+};
+
+// Per-node result
+
+type ListGroupsNode = {
+	node: PiholeNodeRef;
+	groups: Group[];
+	error?: string;
+};
+
+type ListGroupsSummary = {
+	totalNodes: number;
+	okNodes: number;
+	errorNodes: number;
+};
+
+export type ListGroupsResponse = {
+	summary: ListGroupsSummary;
+	nodes: Record<string, ListGroupsNode>;
+};
+
+type GroupMutateNode = {
+	node: PiholeNodeRef;
+	groups: Group[];
+	error?: string;
+};
+
+export type GroupMutateResponse = {
+	nodes: Record<string, GroupMutateNode>;
+};
+
+type RemoveGroupNode = {
+	node: PiholeNodeRef;
+	removed: boolean;
+	error?: string;
+};
+
+type RemoveGroupSummary = {
+	total: number;
+	removed: number;
+	failed: number;
+};
+
+export type RemoveGroupResponse = {
+	summary: RemoveGroupSummary;
+	nodes: Record<string, RemoveGroupNode>;
+};

--- a/frontend/src/types/pihole_client.ts
+++ b/frontend/src/types/pihole_client.ts
@@ -1,0 +1,57 @@
+import type { PiholeNodeRef } from './pihole';
+
+export type PiholeClient = {
+	id: number;
+	ip: string;
+	name: string;
+	comment: string | null;
+	groups: number[];
+	dateAdded: string;
+	dateModified: string;
+};
+
+// Per-node result
+
+type ListClientsNode = {
+	node: PiholeNodeRef;
+	clients: PiholeClient[];
+	error?: string;
+};
+
+type ListClientsSummary = {
+	totalNodes: number;
+	okNodes: number;
+	errorNodes: number;
+};
+
+export type ListClientsResponse = {
+	summary: ListClientsSummary;
+	nodes: Record<string, ListClientsNode>;
+};
+
+type ClientMutateNode = {
+	node: PiholeNodeRef;
+	clients: PiholeClient[];
+	error?: string;
+};
+
+export type ClientMutateResponse = {
+	nodes: Record<string, ClientMutateNode>;
+};
+
+type RemoveClientNode = {
+	node: PiholeNodeRef;
+	removed: boolean;
+	error?: string;
+};
+
+type RemoveClientSummary = {
+	total: number;
+	removed: number;
+	failed: number;
+};
+
+export type RemoveClientResponse = {
+	summary: RemoveClientSummary;
+	nodes: Record<string, RemoveClientNode>;
+};


### PR DESCRIPTION
## Summary

- **Unified `/clients` page** with two panels: Groups (full CRUD) and Clients (list + group assignment + remove)
- **Group management**: add/edit/remove groups with full fan-out to all Pi-hole nodes; Default group (id=0) is shown read-only with no delete button
- **Client management**: lists Pi-hole's configured clients; pencil button opens a checkbox group-assignment dialog; fan-out writes to all nodes
- **Sidebar reorder**: alphabetical order (Adlists → Audit Log → Blocking → Clients → Domains → Home → Query Log → Recent Blocks → Settings → Stats)
- **Domains add-rule dialog**: group multi-select field added (non-fatal fetch of available groups; field is hidden when no groups exist)
- **Adlist update**: `UpdateAdlistCommand` and handler now accept `Groups *[]int` — enables future group re-assignment on update

## Architecture

- `domain/group.go`, `domain/pihole_client.go` — domain types
- `pihole/wire.go` — group + client wire types; updateAdlistWireRequest gets `Groups *[]int`
- 7 new `clientPort` methods: `ListGroups`, `AddGroup`, `UpdateGroup`, `RemoveGroup`, `ListPiholeClients`, `UpdatePiholeClient`, `RemovePiholeClient`
- `service/groupsvc`, `service/piholeClientsvc` — service layer with audit logging
- HTTP v1 `/groups/*` and `/clients/*` routes

## Test plan

- [ ] Navigate to `/clients` — two sections render (Groups, Clients)
- [ ] Add a group → appears in table on all nodes
- [ ] Edit group description / toggle enabled → saves correctly
- [ ] Attempt to delete Default group (id=0) → no delete button rendered
- [ ] Delete a non-default group → removed from all nodes
- [ ] Client list loads (empty state shown gracefully if no clients configured)
- [ ] Pencil on a client → checkbox list shows available groups → Save updates group assignment
- [ ] Sidebar shows Clients entry and all items appear in alphabetical order
- [ ] Domains add-rule dialog shows Groups field when groups exist; omits it when empty
- [ ] All existing pages unaffected (adlists, domains, blocking, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)