### PR TITLE
feat: Site Diagnoser — live blocked-domain capture

### DIFF
--- a/backend/internal/http/api/v1/diagnose_handlers.go
+++ b/backend/internal/http/api/v1/diagnose_handlers.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -40,20 +39,29 @@ func diagnoseStream(d Deps) http.HandlerFunc {
 			return
 		}
 
-		io.WriteString(w, ": hello\n\n")
+		if _, err := fmt.Fprintf(w, ": hello\nretry: 3000\n\n"); err != nil {
+			return
+		}
 		flusher.Flush()
 
 		since := time.Now().UTC()
 		seen := make(map[string]bool)
 
-		ticker := time.NewTicker(2 * time.Second)
-		defer ticker.Stop()
+		pollTicker := time.NewTicker(2 * time.Second)
+		defer pollTicker.Stop()
+		heartbeatTicker := time.NewTicker(30 * time.Second)
+		defer heartbeatTicker.Stop()
 
 		for {
 			select {
 			case <-r.Context().Done():
 				return
-			case <-ticker.C:
+			case <-heartbeatTicker.C:
+				if _, err := fmt.Fprintf(w, ": ping\n\n"); err != nil {
+					return
+				}
+				flusher.Flush()
+			case <-pollTicker.C:
 				until := time.Now().UTC()
 
 				query := domain.QueryLogQuery{
@@ -94,7 +102,9 @@ func diagnoseStream(d Deps) http.HandlerFunc {
 						if err != nil {
 							continue
 						}
-						fmt.Fprintf(w, "event: blocked\ndata: %s\n\n", data)
+						if _, err := fmt.Fprintf(w, "event: blocked\ndata: %s\n\n", data); err != nil {
+							return
+						}
 						flusher.Flush()
 					}
 				}

--- a/backend/internal/http/api/v1/diagnose_handlers.go
+++ b/backend/internal/http/api/v1/diagnose_handlers.go
@@ -1,0 +1,115 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/go-chi/chi"
+)
+
+type diagnoseEventDTO struct {
+	Domain    string `json:"domain"`
+	Client    string `json:"client"`
+	Node      string `json:"node"`
+	Status    string `json:"status"`
+	Timestamp string `json:"timestamp"`
+}
+
+func registerDiagnose(r chi.Router, d Deps) {
+	r.Get("/diagnose/stream", diagnoseStream(d))
+}
+
+func diagnoseStream(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		clientIP := strings.TrimSpace(r.URL.Query().Get("client_ip"))
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache, no-transform")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Accel-Buffering", "no")
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		io.WriteString(w, ": hello\n\n")
+		flusher.Flush()
+
+		since := time.Now().UTC()
+		seen := make(map[string]bool)
+
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-ticker.C:
+				until := time.Now().UTC()
+
+				query := domain.QueryLogQuery{
+					Filters: domain.QueryLogFilters{
+						From:  &since,
+						Until: &until,
+					},
+				}
+				if clientIP != "" {
+					query.Filters.ClientIP = &clientIP
+				}
+
+				resp, err := d.QueryLogService.Fetch(r.Context(), query)
+				if err != nil {
+					d.Logger.Warn().Err(err).Msg("diagnose: failed to fetch query logs")
+					since = until
+					continue
+				}
+
+				for _, nr := range resp.Results {
+					if !nr.Success || nr.Response == nil {
+						continue
+					}
+					for _, entry := range nr.Response.Entries {
+						if !diagnoseIsBlocked(entry.Status) || seen[entry.Domain] {
+							continue
+						}
+						seen[entry.Domain] = true
+
+						evt := diagnoseEventDTO{
+							Domain:    entry.Domain,
+							Client:    entry.ClientIP,
+							Node:      nr.PiholeNode.Name,
+							Status:    entry.Status,
+							Timestamp: entry.Time.UTC().Format(time.RFC3339),
+						}
+						data, err := json.Marshal(evt)
+						if err != nil {
+							continue
+						}
+						fmt.Fprintf(w, "event: blocked\ndata: %s\n\n", data)
+						flusher.Flush()
+					}
+				}
+
+				since = until
+			}
+		}
+	}
+}
+
+func diagnoseIsBlocked(status string) bool {
+	switch status {
+	case "GRAVITY", "BLACKLIST", "REGEX_BLACKLIST",
+		"GRAVITY_CNAME", "REGEX_CNAME", "BLACKLIST_CNAME":
+		return true
+	}
+	return strings.HasPrefix(status, "BLOCKED") || strings.HasPrefix(status, "EXTERNAL_BLOCKED")
+}

--- a/backend/internal/http/api/v1/router.go
+++ b/backend/internal/http/api/v1/router.go
@@ -50,6 +50,7 @@ func RegisterAPIV1(r chi.Router, d Deps) {
 		registerAuthPrivate(r, d)
 		registerClusterBlocking(r, d)
 		registerPiholeClients(r, d)
+		registerDiagnose(r, d)
 		registerGroups(r, d)
 		registerHealth(r, d)
 		registerDomainRules(r, d)

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -18,6 +18,7 @@ import { Account } from '@/pages/Account/Account';
 import { Adlists } from '@/pages/Adlists';
 import { Audit } from '@/pages/Audit';
 import { Clients } from '@/pages/Clients';
+import { Diagnose } from '@/pages/Diagnose';
 import { Stats } from '@/pages/Stats';
 
 export const router = createBrowserRouter([
@@ -71,6 +72,11 @@ export const router = createBrowserRouter([
 						path: '/clients',
 						Component: Clients,
 						handle: { layoutOptions: { pageTitle: 'Clients' } },
+					},
+					{
+						path: '/diagnose',
+						Component: Diagnose,
+						handle: { layoutOptions: { pageTitle: 'Site Diagnoser' } },
 					},
 					{
 						path: '/account',

--- a/frontend/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
 	Home,
 	List,
 	Monitor,
+	Search,
 	Shield,
 	ShieldAlert,
 	SettingsIcon,
@@ -45,6 +46,7 @@ const sections: NavSection[] = [
 			{ to: '/stats', label: 'Stats', icon: BarChart2 },
 			{ to: '/query', label: 'Query Log', icon: FileText },
 			{ to: '/recent-blocks', label: 'Recent Blocks', icon: ShieldAlert },
+			{ to: '/diagnose', label: 'Site Diagnoser', icon: Search },
 		],
 	},
 	{

--- a/frontend/src/pages/Diagnose.module.scss
+++ b/frontend/src/pages/Diagnose.module.scss
@@ -1,0 +1,378 @@
+@use '@/styles/mixins' as *;
+@use '@/styles/variables' as *;
+
+.page {
+	padding: 1.25rem;
+	max-width: 64rem;
+	margin-inline: auto;
+}
+
+.pageHeader {
+	margin-bottom: 1.25rem;
+}
+
+.pageTitle {
+	font-size: 1.25rem;
+	font-weight: 700;
+	color: var(--text-primary);
+	margin: 0 0 0.25rem;
+}
+
+.pageSubtitle {
+	font-size: 0.85rem;
+	color: var(--text-secondary);
+	margin: 0;
+}
+
+/* Control bar */
+.controls {
+	display: flex;
+	align-items: flex-end;
+	gap: 1rem;
+	flex-wrap: wrap;
+	padding: 1rem;
+	background: var(--bg-card);
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+	margin-bottom: 1.25rem;
+}
+
+.ipField {
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+	flex: 1 1 200px;
+}
+
+.ipLabel {
+	font-size: 0.8rem;
+	font-weight: 600;
+	color: var(--text-secondary);
+}
+
+.ipInput {
+	padding: 0.45rem 0.7rem;
+	font-size: 0.875rem;
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+	background: var(--bg-page);
+	color: var(--text-primary);
+	min-width: 0;
+
+	&:focus {
+		outline: 2px solid var(--accent-primary);
+		outline-offset: 1px;
+	}
+
+	&:disabled {
+		opacity: 0.6;
+	}
+}
+
+.controlActions {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	flex-shrink: 0;
+}
+
+/* Timer panel shown while recording */
+.timerPanel {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.6rem 1rem;
+	background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
+	border: 1px solid color-mix(in srgb, var(--accent-primary) 25%, transparent);
+	border-radius: var(--border-radius);
+	margin-bottom: 1.25rem;
+}
+
+.timerDot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: var(--accent-danger);
+	animation: pulse 1s ease-in-out infinite;
+	flex-shrink: 0;
+}
+
+@keyframes pulse {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.3; }
+}
+
+.timerLabel {
+	font-size: 0.85rem;
+	color: var(--text-primary);
+	flex: 1;
+}
+
+.timerCountdown {
+	font-size: 0.85rem;
+	font-weight: 700;
+	color: var(--accent-primary);
+	font-variant-numeric: tabular-nums;
+	min-width: 3ch;
+}
+
+.timerCountdownLow {
+	color: var(--accent-danger);
+}
+
+/* Buttons */
+.startBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.45rem 1rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	color: var(--btn-primary-text);
+	background: var(--btn-primary-bg);
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+	white-space: nowrap;
+
+	&:hover:not(:disabled) { background: var(--btn-primary-bg-hover); }
+	&:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+.stopBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.45rem 1rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	color: var(--btn-danger-text);
+	background: var(--btn-danger-bg);
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+	white-space: nowrap;
+
+	&:hover { background: var(--btn-danger-bg-hover); }
+}
+
+.extendBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.45rem 0.8rem;
+	font-size: 0.85rem;
+	font-weight: 500;
+	color: var(--btn-surface-text);
+	background: var(--btn-surface-bg);
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+	white-space: nowrap;
+
+	&:hover { background: var(--btn-surface-bg-hover); }
+}
+
+.resetBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.45rem 0.8rem;
+	font-size: 0.85rem;
+	font-weight: 500;
+	color: var(--btn-surface-text);
+	background: var(--btn-surface-bg);
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+	white-space: nowrap;
+
+	&:hover { background: var(--btn-surface-bg-hover); }
+}
+
+/* Results */
+.resultsHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 0.6rem;
+}
+
+.resultsCount {
+	font-size: 0.85rem;
+	color: var(--text-secondary);
+}
+
+.liveIndicator {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35rem;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--accent-danger);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.liveDot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: currentColor;
+	animation: pulse 1s ease-in-out infinite;
+}
+
+/* Empty / idle states */
+.emptyState {
+	padding: 3rem 1rem;
+	text-align: center;
+	color: var(--text-secondary);
+	font-size: 0.9rem;
+}
+
+.idleIcon {
+	display: block;
+	margin: 0 auto 0.75rem;
+	opacity: 0.3;
+}
+
+/* Results table */
+.tableWrap {
+	border: 1px solid var(--border-primary);
+	border-radius: var(--border-radius);
+	overflow: hidden;
+}
+
+.table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.875rem;
+
+	thead tr {
+		background: var(--bg-header);
+		color: var(--text-secondary);
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	th, td {
+		padding: 0.55rem 0.75rem;
+		text-align: left;
+		border-bottom: 1px solid var(--border-primary);
+	}
+
+	tbody tr:last-child td {
+		border-bottom: none;
+	}
+
+	tbody tr:hover {
+		background: var(--bg-table-stripe);
+	}
+}
+
+.domainCell {
+	font-family: monospace;
+	font-size: 0.85rem;
+	word-break: break-all;
+}
+
+.clientCell {
+	font-family: monospace;
+	font-size: 0.8rem;
+	color: var(--text-secondary);
+}
+
+.nodeTag {
+	display: inline-block;
+	padding: 0.15rem 0.5rem;
+	background: var(--bg-muted);
+	border-radius: 999px;
+	font-size: 0.75rem;
+	color: var(--text-secondary);
+}
+
+.statusBadge {
+	display: inline-block;
+	padding: 0.15rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.72rem;
+	font-weight: 600;
+}
+
+.statusGravity {
+	background: color-mix(in srgb, var(--accent-warn) 15%, transparent);
+	color: color-mix(in srgb, var(--accent-warn) 80%, var(--text-primary));
+}
+
+.statusRule {
+	background: color-mix(in srgb, var(--accent-danger) 12%, transparent);
+	color: var(--accent-danger);
+}
+
+.actionCell {
+	white-space: nowrap;
+}
+
+.allowBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.3rem;
+	padding: 0.3rem 0.65rem;
+	font-size: 0.8rem;
+	font-weight: 500;
+	color: var(--btn-primary-text);
+	background: var(--accent-success);
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) { background: var(--accent-success-hover); }
+	&:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+.removeBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.3rem;
+	padding: 0.3rem 0.65rem;
+	font-size: 0.8rem;
+	font-weight: 500;
+	color: var(--btn-danger-text);
+	background: var(--btn-danger-bg);
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) { background: var(--btn-danger-bg-hover); }
+	&:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+.actionFeedback {
+	font-size: 0.8rem;
+	font-weight: 500;
+}
+
+.feedbackOk {
+	color: var(--accent-success);
+}
+
+.feedbackErr {
+	color: var(--accent-danger);
+}
+
+.spin {
+	animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+	from { transform: rotate(0deg); }
+	to { transform: rotate(360deg); }
+}

--- a/frontend/src/pages/Diagnose.module.scss
+++ b/frontend/src/pages/Diagnose.module.scss
@@ -158,25 +158,9 @@
 	&:hover { background: var(--btn-danger-bg-hover); }
 }
 
+/* Shared surface style used by Extend and Clear buttons */
+.surfaceBtn,
 .extendBtn {
-	display: inline-flex;
-	align-items: center;
-	gap: 0.4rem;
-	padding: 0.45rem 0.8rem;
-	font-size: 0.85rem;
-	font-weight: 500;
-	color: var(--btn-surface-text);
-	background: var(--btn-surface-bg);
-	border: 1px solid var(--border-primary);
-	border-radius: var(--border-radius);
-	cursor: pointer;
-	transition: background var(--transition-fast);
-	white-space: nowrap;
-
-	&:hover { background: var(--btn-surface-bg-hover); }
-}
-
-.resetBtn {
 	display: inline-flex;
 	align-items: center;
 	gap: 0.4rem;
@@ -310,9 +294,14 @@
 	color: color-mix(in srgb, var(--accent-warn) 80%, var(--text-primary));
 }
 
-.statusRule {
+.statusExactRule {
 	background: color-mix(in srgb, var(--accent-danger) 12%, transparent);
 	color: var(--accent-danger);
+}
+
+.statusRegexRule {
+	background: color-mix(in srgb, var(--accent-warn) 20%, transparent);
+	color: color-mix(in srgb, var(--accent-warn) 70%, var(--text-primary));
 }
 
 .actionCell {

--- a/frontend/src/pages/Diagnose.tsx
+++ b/frontend/src/pages/Diagnose.tsx
@@ -1,0 +1,350 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Circle, RefreshCw, Shield, Square, Timer } from 'lucide-react';
+import { addDomainRule, removeDomainRule } from '@/lib/api/domainrules';
+import classNames from 'classnames';
+import styles from './Diagnose.module.scss';
+
+const DEFAULT_DURATION_S = 60;
+const EXTEND_S = 30;
+
+type BlockedBy = 'rule' | 'gravity';
+
+type ActionState = 'idle' | 'loading' | 'ok' | 'error';
+
+type BlockedEntry = {
+	domain: string;
+	client: string;
+	node: string;
+	status: string;
+	timestamp: string;
+	blockedBy: BlockedBy;
+	actionState: ActionState;
+};
+
+type RawEvent = {
+	domain: string;
+	client: string;
+	node: string;
+	status: string;
+	timestamp: string;
+};
+
+type RecordState = 'idle' | 'recording' | 'stopped';
+
+function classifyStatus(status: string): BlockedBy {
+	if (status === 'BLACKLIST' || status === 'BLACKLIST_CNAME') return 'rule';
+	return 'gravity';
+}
+
+export function Diagnose() {
+	const [recordState, setRecordState] = useState<RecordState>('idle');
+	const [clientIP, setClientIP] = useState('');
+	const [entries, setEntries] = useState<BlockedEntry[]>([]);
+	const [secondsLeft, setSecondsLeft] = useState(DEFAULT_DURATION_S);
+
+	const esRef = useRef<EventSource | null>(null);
+	const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const feedbackTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+	const stopRecording = useCallback(() => {
+		esRef.current?.close();
+		esRef.current = null;
+		if (countdownRef.current) {
+			clearInterval(countdownRef.current);
+			countdownRef.current = null;
+		}
+		setRecordState('stopped');
+	}, []);
+
+	const startRecording = useCallback(() => {
+		setEntries([]);
+		setSecondsLeft(DEFAULT_DURATION_S);
+		setRecordState('recording');
+
+		const qs = clientIP.trim() ? `?client_ip=${encodeURIComponent(clientIP.trim())}` : '';
+		const es = new EventSource(`/api/v1/diagnose/stream${qs}`, { withCredentials: true });
+
+		es.addEventListener('blocked', (ev: MessageEvent) => {
+			try {
+				const raw: RawEvent = JSON.parse(ev.data);
+				setEntries((prev) => {
+					if (prev.some((e) => e.domain === raw.domain)) return prev;
+					return [
+						{
+							domain: raw.domain,
+							client: raw.client,
+							node: raw.node,
+							status: raw.status,
+							timestamp: raw.timestamp,
+							blockedBy: classifyStatus(raw.status),
+							actionState: 'idle',
+						},
+						...prev,
+					];
+				});
+			} catch {
+				// malformed event — ignore
+			}
+		});
+
+		es.onerror = () => {
+			// SSE errors are non-fatal; the browser will retry automatically.
+			// Don't stop the session on transient errors.
+		};
+
+		esRef.current = es;
+
+		const interval = setInterval(() => {
+			setSecondsLeft((s) => {
+				if (s <= 1) {
+					stopRecording();
+					return 0;
+				}
+				return s - 1;
+			});
+		}, 1000);
+		countdownRef.current = interval;
+	}, [clientIP, stopRecording]);
+
+	const handleExtend = () => {
+		setSecondsLeft((s) => s + EXTEND_S);
+	};
+
+	const handleReset = () => {
+		setEntries([]);
+		setRecordState('idle');
+		setSecondsLeft(DEFAULT_DURATION_S);
+	};
+
+	useEffect(() => {
+		return () => {
+			esRef.current?.close();
+			if (countdownRef.current) clearInterval(countdownRef.current);
+			for (const t of feedbackTimers.current.values()) clearTimeout(t);
+		};
+	}, []);
+
+	function scheduleActionReset(domain: string) {
+		const existing = feedbackTimers.current.get(domain);
+		if (existing) clearTimeout(existing);
+		const t = setTimeout(() => {
+			setEntries((prev) =>
+				prev.map((e) => (e.domain === domain ? { ...e, actionState: 'idle' } : e)),
+			);
+			feedbackTimers.current.delete(domain);
+		}, 3000);
+		feedbackTimers.current.set(domain, t);
+	}
+
+	async function handleAction(entry: BlockedEntry) {
+		setEntries((prev) =>
+			prev.map((e) => (e.domain === entry.domain ? { ...e, actionState: 'loading' } : e)),
+		);
+		try {
+			if (entry.blockedBy === 'rule') {
+				await removeDomainRule('deny', 'exact', entry.domain);
+			} else {
+				await addDomainRule('allow', 'exact', entry.domain);
+			}
+			setEntries((prev) =>
+				prev.map((e) => (e.domain === entry.domain ? { ...e, actionState: 'ok' } : e)),
+			);
+		} catch {
+			setEntries((prev) =>
+				prev.map((e) => (e.domain === entry.domain ? { ...e, actionState: 'error' } : e)),
+			);
+		}
+		scheduleActionReset(entry.domain);
+	}
+
+	const isRecording = recordState === 'recording';
+	const isStopped = recordState === 'stopped';
+	const isIdle = recordState === 'idle';
+	const isLow = secondsLeft <= 15;
+
+	return (
+		<div className={styles.page}>
+			<div className={styles.pageHeader}>
+				<h1 className={styles.pageTitle}>Site Diagnoser</h1>
+				<p className={styles.pageSubtitle}>
+					Start recording, open the broken site in another tab, then stop to review blocked
+					domains.
+				</p>
+			</div>
+
+			<div className={styles.controls}>
+				<div className={styles.ipField}>
+					<label htmlFor='diag-ip' className={styles.ipLabel}>
+						Client IP (optional — leave blank to watch all devices)
+					</label>
+					<input
+						id='diag-ip'
+						type='text'
+						className={styles.ipInput}
+						placeholder='e.g. 192.168.1.42'
+						value={clientIP}
+						onChange={(e) => setClientIP(e.target.value)}
+						disabled={isRecording}
+					/>
+				</div>
+
+				<div className={styles.controlActions}>
+					{(isIdle || isStopped) && (
+						<button type='button' className={styles.startBtn} onClick={startRecording}>
+							<Circle size={14} />
+							{isStopped ? 'Record again' : 'Start recording'}
+						</button>
+					)}
+					{isRecording && (
+						<>
+							<button type='button' className={styles.extendBtn} onClick={handleExtend}>
+								<Timer size={14} />
+								+{EXTEND_S}s
+							</button>
+							<button type='button' className={styles.stopBtn} onClick={stopRecording}>
+								<Square size={14} />
+								Stop
+							</button>
+						</>
+					)}
+					{isStopped && entries.length > 0 && (
+						<button type='button' className={styles.resetBtn} onClick={handleReset}>
+							Clear
+						</button>
+					)}
+				</div>
+			</div>
+
+			{isRecording && (
+				<div className={styles.timerPanel}>
+					<span className={styles.timerDot} />
+					<span className={styles.timerLabel}>
+						Recording — open the broken site in another tab
+					</span>
+					<span
+						className={classNames(styles.timerCountdown, { [styles.timerCountdownLow]: isLow })}
+					>
+						{secondsLeft}s
+					</span>
+				</div>
+			)}
+
+			{entries.length > 0 ? (
+				<>
+					<div className={styles.resultsHeader}>
+						<span className={styles.resultsCount}>
+							{entries.length} blocked {entries.length === 1 ? 'domain' : 'domains'} captured
+						</span>
+						{isRecording && (
+							<span className={styles.liveIndicator}>
+								<span className={styles.liveDot} />
+								Live
+							</span>
+						)}
+					</div>
+					<div className={styles.tableWrap}>
+						<table className={styles.table}>
+							<thead>
+								<tr>
+									<th>Domain</th>
+									<th>Client</th>
+									<th>Node</th>
+									<th>Blocked by</th>
+									<th aria-label='Action' />
+								</tr>
+							</thead>
+							<tbody>
+								{entries.map((entry) => (
+									<tr key={entry.domain}>
+										<td className={styles.domainCell}>{entry.domain}</td>
+										<td className={styles.clientCell}>{entry.client || '—'}</td>
+										<td>
+											<span className={styles.nodeTag}>{entry.node}</span>
+										</td>
+										<td>
+											<span
+												className={classNames(styles.statusBadge, {
+													[styles.statusRule]: entry.blockedBy === 'rule',
+													[styles.statusGravity]: entry.blockedBy === 'gravity',
+												})}
+											>
+												{entry.blockedBy === 'rule' ? 'Block rule' : 'Gravity list'}
+											</span>
+										</td>
+										<td className={styles.actionCell}>
+											{entry.actionState === 'ok' && (
+												<span
+													className={classNames(
+														styles.actionFeedback,
+														styles.feedbackOk,
+													)}
+												>
+													✓{' '}
+													{entry.blockedBy === 'rule'
+														? 'Rule removed'
+														: 'Allow rule added'}
+												</span>
+											)}
+											{entry.actionState === 'error' && (
+												<span
+													className={classNames(
+														styles.actionFeedback,
+														styles.feedbackErr,
+													)}
+												>
+													✗ Failed
+												</span>
+											)}
+											{entry.actionState === 'idle' &&
+												entry.blockedBy === 'gravity' && (
+													<button
+														type='button'
+														className={styles.allowBtn}
+														onClick={() => handleAction(entry)}
+														title={`Add "${entry.domain}" to allowlist`}
+													>
+														<Shield size={12} />
+														Allow
+													</button>
+												)}
+											{entry.actionState === 'idle' &&
+												entry.blockedBy === 'rule' && (
+													<button
+														type='button'
+														className={styles.removeBtn}
+														onClick={() => handleAction(entry)}
+														title={`Remove block rule for "${entry.domain}"`}
+													>
+														Remove rule
+													</button>
+												)}
+											{entry.actionState === 'loading' && (
+												<RefreshCw size={14} className={styles.spin} />
+											)}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</>
+			) : (
+				<div className={styles.emptyState}>
+					{isIdle && (
+						<>
+							<Circle
+								size={36}
+								className={styles.idleIcon}
+								aria-hidden='true'
+							/>
+							Enter an optional client IP, then click Start recording. Open the broken
+							site in another tab — blocked domains will appear here in real time.
+						</>
+					)}
+					{isRecording && 'Waiting for blocked DNS queries…'}
+					{isStopped && 'No blocked domains were captured.'}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/pages/Diagnose.tsx
+++ b/frontend/src/pages/Diagnose.tsx
@@ -6,8 +6,12 @@ import styles from './Diagnose.module.scss';
 
 const DEFAULT_DURATION_S = 60;
 const EXTEND_S = 30;
+const SSE_ERROR_THRESHOLD = 3;
 
-type BlockedBy = 'rule' | 'gravity';
+// gravity  → blocked by adlist/gravity; offer Add allow rule
+// exact-rule → blocked by exact deny rule; offer Remove rule
+// regex-rule → blocked by regex deny rule; can't remove by domain, offer Add allow rule
+type BlockedBy = 'gravity' | 'exact-rule' | 'regex-rule';
 
 type ActionState = 'idle' | 'loading' | 'ok' | 'error';
 
@@ -32,7 +36,8 @@ type RawEvent = {
 type RecordState = 'idle' | 'recording' | 'stopped';
 
 function classifyStatus(status: string): BlockedBy {
-	if (status === 'BLACKLIST' || status === 'BLACKLIST_CNAME') return 'rule';
+	if (status === 'BLACKLIST' || status === 'BLACKLIST_CNAME') return 'exact-rule';
+	if (status === 'REGEX_BLACKLIST' || status === 'REGEX_CNAME') return 'regex-rule';
 	return 'gravity';
 }
 
@@ -41,10 +46,12 @@ export function Diagnose() {
 	const [clientIP, setClientIP] = useState('');
 	const [entries, setEntries] = useState<BlockedEntry[]>([]);
 	const [secondsLeft, setSecondsLeft] = useState(DEFAULT_DURATION_S);
+	const [sseConnectionLost, setSseConnectionLost] = useState(false);
 
 	const esRef = useRef<EventSource | null>(null);
 	const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const feedbackTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+	const sseErrorCountRef = useRef(0);
 
 	const stopRecording = useCallback(() => {
 		esRef.current?.close();
@@ -53,18 +60,33 @@ export function Diagnose() {
 			clearInterval(countdownRef.current);
 			countdownRef.current = null;
 		}
+		sseErrorCountRef.current = 0;
+		setSseConnectionLost(false);
 		setRecordState('stopped');
 	}, []);
+
+	// Expire the session when the countdown reaches zero — kept outside the
+	// setSecondsLeft updater so it's a pure state observation, not a side effect
+	// inside a state setter (which React may invoke multiple times in StrictMode).
+	useEffect(() => {
+		if (secondsLeft === 0 && recordState === 'recording') {
+			stopRecording();
+		}
+	}, [secondsLeft, recordState, stopRecording]);
 
 	const startRecording = useCallback(() => {
 		setEntries([]);
 		setSecondsLeft(DEFAULT_DURATION_S);
+		setSseConnectionLost(false);
+		sseErrorCountRef.current = 0;
 		setRecordState('recording');
 
 		const qs = clientIP.trim() ? `?client_ip=${encodeURIComponent(clientIP.trim())}` : '';
 		const es = new EventSource(`/api/v1/diagnose/stream${qs}`, { withCredentials: true });
 
 		es.addEventListener('blocked', (ev: MessageEvent) => {
+			sseErrorCountRef.current = 0;
+			setSseConnectionLost(false);
 			try {
 				const raw: RawEvent = JSON.parse(ev.data);
 				setEntries((prev) => {
@@ -88,23 +110,19 @@ export function Diagnose() {
 		});
 
 		es.onerror = () => {
-			// SSE errors are non-fatal; the browser will retry automatically.
-			// Don't stop the session on transient errors.
+			sseErrorCountRef.current++;
+			if (sseErrorCountRef.current >= SSE_ERROR_THRESHOLD) {
+				setSseConnectionLost(true);
+			}
 		};
 
 		esRef.current = es;
 
 		const interval = setInterval(() => {
-			setSecondsLeft((s) => {
-				if (s <= 1) {
-					stopRecording();
-					return 0;
-				}
-				return s - 1;
-			});
+			setSecondsLeft((s) => (s > 0 ? s - 1 : 0));
 		}, 1000);
 		countdownRef.current = interval;
-	}, [clientIP, stopRecording]);
+	}, [clientIP]);
 
 	const handleExtend = () => {
 		setSecondsLeft((s) => s + EXTEND_S);
@@ -114,6 +132,7 @@ export function Diagnose() {
 		setEntries([]);
 		setRecordState('idle');
 		setSecondsLeft(DEFAULT_DURATION_S);
+		setSseConnectionLost(false);
 	};
 
 	useEffect(() => {
@@ -141,7 +160,7 @@ export function Diagnose() {
 			prev.map((e) => (e.domain === entry.domain ? { ...e, actionState: 'loading' } : e)),
 		);
 		try {
-			if (entry.blockedBy === 'rule') {
+			if (entry.blockedBy === 'exact-rule') {
 				await removeDomainRule('deny', 'exact', entry.domain);
 			} else {
 				await addDomainRule('allow', 'exact', entry.domain);
@@ -161,6 +180,17 @@ export function Diagnose() {
 	const isStopped = recordState === 'stopped';
 	const isIdle = recordState === 'idle';
 	const isLow = secondsLeft <= 15;
+
+	function blockedByLabel(b: BlockedBy) {
+		if (b === 'exact-rule') return 'Block rule';
+		if (b === 'regex-rule') return 'Regex rule';
+		return 'Gravity list';
+	}
+
+	function actionLabel(entry: BlockedEntry) {
+		if (entry.blockedBy === 'exact-rule') return 'Rule removed';
+		return 'Allow rule added';
+	}
 
 	return (
 		<div className={styles.page}>
@@ -208,7 +238,7 @@ export function Diagnose() {
 						</>
 					)}
 					{isStopped && entries.length > 0 && (
-						<button type='button' className={styles.resetBtn} onClick={handleReset}>
+						<button type='button' className={styles.surfaceBtn} onClick={handleReset}>
 							Clear
 						</button>
 					)}
@@ -219,10 +249,14 @@ export function Diagnose() {
 				<div className={styles.timerPanel}>
 					<span className={styles.timerDot} />
 					<span className={styles.timerLabel}>
-						Recording — open the broken site in another tab
+						{sseConnectionLost
+							? 'Connection lost — retrying…'
+							: 'Recording — open the broken site in another tab'}
 					</span>
 					<span
-						className={classNames(styles.timerCountdown, { [styles.timerCountdownLow]: isLow })}
+						className={classNames(styles.timerCountdown, {
+							[styles.timerCountdownLow]: isLow,
+						})}
 					>
 						{secondsLeft}s
 					</span>
@@ -233,7 +267,8 @@ export function Diagnose() {
 				<>
 					<div className={styles.resultsHeader}>
 						<span className={styles.resultsCount}>
-							{entries.length} blocked {entries.length === 1 ? 'domain' : 'domains'} captured
+							{entries.length} blocked {entries.length === 1 ? 'domain' : 'domains'}{' '}
+							captured
 						</span>
 						{isRecording && (
 							<span className={styles.liveIndicator}>
@@ -264,11 +299,15 @@ export function Diagnose() {
 										<td>
 											<span
 												className={classNames(styles.statusBadge, {
-													[styles.statusRule]: entry.blockedBy === 'rule',
-													[styles.statusGravity]: entry.blockedBy === 'gravity',
+													[styles.statusExactRule]:
+														entry.blockedBy === 'exact-rule',
+													[styles.statusRegexRule]:
+														entry.blockedBy === 'regex-rule',
+													[styles.statusGravity]:
+														entry.blockedBy === 'gravity',
 												})}
 											>
-												{entry.blockedBy === 'rule' ? 'Block rule' : 'Gravity list'}
+												{blockedByLabel(entry.blockedBy)}
 											</span>
 										</td>
 										<td className={styles.actionCell}>
@@ -279,10 +318,7 @@ export function Diagnose() {
 														styles.feedbackOk,
 													)}
 												>
-													✓{' '}
-													{entry.blockedBy === 'rule'
-														? 'Rule removed'
-														: 'Allow rule added'}
+													✓ {actionLabel(entry)}
 												</span>
 											)}
 											{entry.actionState === 'error' && (
@@ -296,7 +332,18 @@ export function Diagnose() {
 												</span>
 											)}
 											{entry.actionState === 'idle' &&
-												entry.blockedBy === 'gravity' && (
+												entry.blockedBy === 'exact-rule' && (
+													<button
+														type='button'
+														className={styles.removeBtn}
+														onClick={() => handleAction(entry)}
+														title={`Remove block rule for "${entry.domain}"`}
+													>
+														Remove rule
+													</button>
+												)}
+											{entry.actionState === 'idle' &&
+												entry.blockedBy !== 'exact-rule' && (
 													<button
 														type='button'
 														className={styles.allowBtn}
@@ -305,17 +352,6 @@ export function Diagnose() {
 													>
 														<Shield size={12} />
 														Allow
-													</button>
-												)}
-											{entry.actionState === 'idle' &&
-												entry.blockedBy === 'rule' && (
-													<button
-														type='button'
-														className={styles.removeBtn}
-														onClick={() => handleAction(entry)}
-														title={`Remove block rule for "${entry.domain}"`}
-													>
-														Remove rule
 													</button>
 												)}
 											{entry.actionState === 'loading' && (
@@ -332,13 +368,9 @@ export function Diagnose() {
 				<div className={styles.emptyState}>
 					{isIdle && (
 						<>
-							<Circle
-								size={36}
-								className={styles.idleIcon}
-								aria-hidden='true'
-							/>
-							Enter an optional client IP, then click Start recording. Open the broken
-							site in another tab — blocked domains will appear here in real time.
+							<Circle size={36} className={styles.idleIcon} aria-hidden='true' />
+							Enter an optional client IP, then click Start recording. Open the broken site
+							in another tab — blocked domains will appear here in real time.
 						</>
 					)}
 					{isRecording && 'Waiting for blocked DNS queries…'}

--- a/frontend/src/pages/Diagnose.tsx
+++ b/frontend/src/pages/Diagnose.tsx
@@ -116,6 +116,11 @@ export function Diagnose() {
 			}
 		};
 
+		es.onopen = () => {
+			sseErrorCountRef.current = 0;
+			setSseConnectionLost(false);
+		};
+
 		esRef.current = es;
 
 		const interval = setInterval(() => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,6 +32,20 @@ export default defineConfig({
 					});
 				},
 			},
+			'/api/v1/diagnose/stream': {
+				target: 'http://localhost:8081',
+				changeOrigin: true,
+				ws: false,
+				proxyTimeout: 0,
+				timeout: 0,
+				configure: (proxy) => {
+					proxy.on('proxyRes', (res) => {
+						delete (res.headers as any)['content-length'];
+						res.headers['cache-control'] = 'no-cache, no-transform';
+						res.headers['connection'] = 'keep-alive';
+					});
+				},
+			},
 			'/api': 'http://localhost:8081',
 		},
 	},


### PR DESCRIPTION
## Summary

- New `/diagnose` page for admins to identify which domains Pi-hole is blocking for a specific device or the whole network
- Admin sets an optional client IP filter, clicks **Start recording**, then opens the broken site in another tab — blocked domains stream in via SSE in real time
- Countdown timer (60 s default) with **+30 s** extend button and **Stop** button; timer expires automatically with a visual warning when ≤ 15 s remain
- Per-domain action: **Add allow rule** (gravity/list blocks) or **Remove block rule** (exact block rules), with inline success/error feedback
- "Site Diagnoser" nav item added to the Monitoring sidebar section

## Implementation

- **Backend**: new `GET /api/v1/diagnose/stream` SSE endpoint that polls `QueryLogService.Fetch` every 2 s, filters blocked statuses, deduplicates by domain across the session, and streams `event: blocked` SSE events; no DB writes; stateless beyond the live connection
- **Frontend**: `Diagnose.tsx` manages a local `EventSource` instance (not the shared SSE client), countdown state, and per-entry action state; reuses `addDomainRule` / `removeDomainRule` from existing API layer
- **Vite proxy**: added SSE-friendly proxy entry for `/api/v1/diagnose/stream` (no timeout, no content-length) matching the existing `/api/events` pattern

## Test plan

- [ ] Navigate to `/diagnose`; verify page loads and "Site Diagnoser" appears in sidebar
- [ ] Click Start recording without a client IP; make a blocked DNS lookup; verify the domain appears in the results table
- [ ] Enter a specific client IP; verify only queries from that IP appear
- [ ] Verify countdown counts down; click Extend (+30 s); verify timer increases
- [ ] Let timer expire; verify recording stops automatically
- [ ] On a gravity-blocked domain, click Allow; verify domain appears on `/domains` allowlist
- [ ] On a manually-blocked domain, click Remove rule; verify rule disappears from `/domains`
- [ ] Click Stop during recording; verify list freezes
- [ ] Click "Record again"; verify state resets and a new session starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)