### PR TITLE
feat: Restart DNS cluster action

### DIFF
--- a/backend/internal/http/api/v1/cluster_blocking_dto.go
+++ b/backend/internal/http/api/v1/cluster_blocking_dto.go
@@ -63,3 +63,24 @@ type flushCacheResponseDTO struct {
 	Summary flushCacheSummaryDTO        `json:"summary"`
 	Nodes   map[int64]flushCacheNodeDTO `json:"nodes"`
 }
+
+type restartDNSSummaryDTO struct {
+	Total     int `json:"total"`
+	Succeeded int `json:"succeeded"`
+	Failed    int `json:"failed"`
+}
+
+type restartDNSNodeDTO struct {
+	Node struct {
+		Id   int64  `json:"id"`
+		Name string `json:"name"`
+		Host string `json:"host"`
+	} `json:"node"`
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+}
+
+type restartDNSResponseDTO struct {
+	Summary restartDNSSummaryDTO        `json:"summary"`
+	Nodes   map[int64]restartDNSNodeDTO `json:"nodes"`
+}

--- a/backend/internal/http/api/v1/cluster_blocking_handlers.go
+++ b/backend/internal/http/api/v1/cluster_blocking_handlers.go
@@ -16,6 +16,7 @@ func registerClusterBlocking(r chi.Router, d Deps) {
 		r.Post("/", clusterBlockingPost(d))
 		r.Post("/nodes/{id}", clusterBlockingPostNode(d))
 		r.Post("/flush-cache", clusterFlushCache(d))
+		r.Post("/restart-dns", clusterRestartDNS(d))
 	})
 }
 
@@ -81,6 +82,36 @@ func clusterFlushCache(d Deps) http.HandlerFunc {
 		results := d.ClusterBlockingService.FlushCache(r.Context())
 		transport.WriteJSON(w, http.StatusOK, flushCacheResponseFromDomain(results))
 	}
+}
+
+func clusterRestartDNS(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		results := d.ClusterBlockingService.RestartDNS(r.Context())
+		transport.WriteJSON(w, http.StatusOK, restartDNSResponseFromDomain(results))
+	}
+}
+
+func restartDNSResponseFromDomain(results map[int64]*domain.NodeResult[struct{}]) restartDNSResponseDTO {
+	dto := restartDNSResponseDTO{
+		Nodes: make(map[int64]restartDNSNodeDTO, len(results)),
+	}
+	dto.Summary.Total = len(results)
+	for id, nr := range results {
+		node := restartDNSNodeDTO{
+			Success: nr.Success,
+			Error:   util.ErrorString(nr.Error),
+		}
+		node.Node.Id = nr.PiholeNode.Id
+		node.Node.Name = nr.PiholeNode.Name
+		node.Node.Host = nr.PiholeNode.Host
+		if nr.Success {
+			dto.Summary.Succeeded++
+		} else {
+			dto.Summary.Failed++
+		}
+		dto.Nodes[id] = node
+	}
+	return dto
 }
 
 func flushCacheResponseFromDomain(results map[int64]*domain.NodeResult[struct{}]) flushCacheResponseDTO {

--- a/backend/internal/http/api/v1/interface.go
+++ b/backend/internal/http/api/v1/interface.go
@@ -48,6 +48,7 @@ type clusterBlockingService interface {
 	SetState(ctx context.Context, blocking bool, timer *int) (*domain.ClusterBlockingState, error)
 	SetStateForNode(ctx context.Context, nodeID int64, blocking bool, timer *int) (*domain.ClusterBlockingState, error)
 	FlushCache(ctx context.Context) map[int64]*domain.NodeResult[struct{}]
+	RestartDNS(ctx context.Context) map[int64]*domain.NodeResult[struct{}]
 }
 
 type domainRuleService interface {

--- a/backend/internal/pihole/client.go
+++ b/backend/internal/pihole/client.go
@@ -1094,6 +1094,23 @@ func (c *Client) RebuildGravity(ctx context.Context) error {
 	return nil
 }
 
+func (c *Client) RestartDNS(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.getBaseURL()+"/action/restartDNS", nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return fmt.Errorf("restarting DNS: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return &httpStatusError{Status: resp.StatusCode}
+	}
+	return nil
+}
+
 func (c *Client) FlushCache(ctx context.Context) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.getBaseURL()+"/action/flush/cache", nil)
 	if err != nil {

--- a/backend/internal/pihole/cluster.go
+++ b/backend/internal/pihole/cluster.go
@@ -414,6 +414,13 @@ func (c *Cluster) FlushCache(ctx context.Context) map[int64]*domain.NodeResult[s
 	return out
 }
 
+func (c *Cluster) RestartDNS(ctx context.Context) map[int64]*domain.NodeResult[struct{}] {
+	out, _ := fanout(c, ctx, 0, 10*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (struct{}, error) {
+		return struct{}{}, client.RestartDNS(nodeCtx)
+	})
+	return out
+}
+
 // Groups
 
 func (c *Cluster) ListGroups(ctx context.Context) map[int64]*domain.NodeResult[*domain.GroupSet] {

--- a/backend/internal/pihole/interface.go
+++ b/backend/internal/pihole/interface.go
@@ -27,6 +27,7 @@ type clientPort interface {
 	RemoveAdlist(ctx context.Context, cmd domain.RemoveAdlistCommand) error
 	RebuildGravity(ctx context.Context) error
 	FlushCache(ctx context.Context) error
+	RestartDNS(ctx context.Context) error
 	AuthStatus(ctx context.Context) (*domain.AuthStatus, error)
 	Logout(ctx context.Context) error
 	GetStatsSummary(ctx context.Context) (*domain.StatsSummary, error)

--- a/backend/internal/service/clusterblocking/interface.go
+++ b/backend/internal/service/clusterblocking/interface.go
@@ -11,6 +11,7 @@ type cluster interface {
 	SetBlockingState(ctx context.Context, blocking bool, timer *int) map[int64]*domain.NodeResult[*domain.BlockingState]
 	SetBlockingStateForNode(ctx context.Context, nodeID int64, blocking bool, timer *int) (*domain.NodeResult[*domain.BlockingState], error)
 	FlushCache(ctx context.Context) map[int64]*domain.NodeResult[struct{}]
+	RestartDNS(ctx context.Context) map[int64]*domain.NodeResult[struct{}]
 }
 
 type broker interface {

--- a/backend/internal/service/clusterblocking/service.go
+++ b/backend/internal/service/clusterblocking/service.go
@@ -149,6 +149,10 @@ func (s *Service) FlushCache(ctx context.Context) map[int64]*domain.NodeResult[s
 	return s.cluster.FlushCache(ctx)
 }
 
+func (s *Service) RestartDNS(ctx context.Context) map[int64]*domain.NodeResult[struct{}] {
+	return s.cluster.RestartDNS(ctx)
+}
+
 func (s *Service) StartPublisher(ctx context.Context) {
 	s.logger.Info().Msg("Starting cluster blocking service")
 	s.getAndPublish(ctx)

--- a/frontend/src/lib/api/blocking.ts
+++ b/frontend/src/lib/api/blocking.ts
@@ -40,3 +40,18 @@ export type FlushCacheResult = {
 export async function flushCache(): Promise<FlushCacheResult> {
 	return apiV1Fetch<FlushCacheResult>('/cluster/blocking/flush-cache', { method: 'POST' });
 }
+
+export type RestartDNSNodeResult = {
+	node: { id: number; name: string; host: string };
+	success: boolean;
+	error?: string;
+};
+
+export type RestartDNSResult = {
+	summary: { total: number; succeeded: number; failed: number };
+	nodes: Record<number, RestartDNSNodeResult>;
+};
+
+export async function restartDNS(): Promise<RestartDNSResult> {
+	return apiV1Fetch<RestartDNSResult>('/cluster/blocking/restart-dns', { method: 'POST' });
+}

--- a/frontend/src/pages/Blocking/Blocking.module.scss
+++ b/frontend/src/pages/Blocking/Blocking.module.scss
@@ -439,6 +439,12 @@
 	align-items: center;
 	gap: 1rem;
 	flex-wrap: wrap;
+
+	& + & {
+		margin-top: 1rem;
+		padding-top: 1rem;
+		border-top: 1px solid var(--border-card);
+	}
 }
 
 .quickActionInfo {

--- a/frontend/src/pages/Blocking/Blocking.module.scss
+++ b/frontend/src/pages/Blocking/Blocking.module.scss
@@ -486,7 +486,7 @@
 	&:disabled { opacity: 0.6; cursor: not-allowed; }
 }
 
-.flushResults {
+.actionResults {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 0.5rem;
@@ -496,17 +496,17 @@
 	font-size: 0.82rem;
 }
 
-.flushNodeOk {
+.actionNodeOk {
 	color: var(--accent-success);
 	font-weight: 500;
 }
 
-.flushNodeErr {
+.actionNodeErr {
 	color: var(--accent-danger);
 	font-weight: 500;
 }
 
-.flushNodeErrMsg {
+.actionNodeErrMsg {
 	font-weight: 400;
 	opacity: 0.85;
 }

--- a/frontend/src/pages/Blocking/Blocking.tsx
+++ b/frontend/src/pages/Blocking/Blocking.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
-import { Shield, Loader2, ChevronDown, RefreshCw } from 'lucide-react';
+import { Shield, Loader2, ChevronDown, RefreshCw, RotateCcw } from 'lucide-react';
 import { useClusterOverview } from '@/hooks/useClusterOverview';
-import { setClusterBlocking, setNodeBlocking, flushCache } from '@/lib/api/blocking';
-import type { FlushCacheResult } from '@/lib/api/blocking';
+import { setClusterBlocking, setNodeBlocking, flushCache, restartDNS } from '@/lib/api/blocking';
+import type { FlushCacheResult, RestartDNSResult } from '@/lib/api/blocking';
 import type { ClusterBlockingNode } from '@/types/blocking';
 import { getBlockingDisplayState } from '@/utils/blockingStatus';
 import styles from './Blocking.module.scss';
@@ -62,6 +62,10 @@ export function Blocking() {
 	const [flushResult, setFlushResult] = useState<FlushCacheResult | null>(null);
 	const [flushError, setFlushError] = useState<string | null>(null);
 	const flushResultTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [restartSubmitting, setRestartSubmitting] = useState(false);
+	const [restartResult, setRestartResult] = useState<RestartDNSResult | null>(null);
+	const [restartError, setRestartError] = useState<string | null>(null);
+	const restartResultTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const [customSeconds, setCustomSeconds] = useState(60);
 	const [customUnit, setCustomUnit] = useState<CustomUnit>('mins');
 	const [customSecondsByNode, setCustomSecondsByNode] = useState<Record<number, number>>({});
@@ -248,6 +252,24 @@ export function Blocking() {
 		}
 	}
 
+	async function handleRestartDNS() {
+		setRestartSubmitting(true);
+		setRestartResult(null);
+		setRestartError(null);
+		if (restartResultTimer.current) clearTimeout(restartResultTimer.current);
+		try {
+			const result = await restartDNS();
+			setRestartResult(result);
+			restartResultTimer.current = setTimeout(() => setRestartResult(null), 5000);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : 'Failed to restart DNS';
+			setRestartError(msg);
+			restartResultTimer.current = setTimeout(() => setRestartError(null), 5000);
+		} finally {
+			setRestartSubmitting(false);
+		}
+	}
+
 	async function handleFlushCache() {
 		setFlushSubmitting(true);
 		setFlushResult(null);
@@ -269,6 +291,7 @@ export function Blocking() {
 	useEffect(() => {
 		return () => {
 			if (flushResultTimer.current) clearTimeout(flushResultTimer.current);
+			if (restartResultTimer.current) clearTimeout(restartResultTimer.current);
 		};
 	}, []);
 
@@ -572,6 +595,53 @@ export function Blocking() {
 					{flushResult && (
 						<div className={styles.flushResults} role='status' aria-live='polite'>
 							{Object.values(flushResult.nodes)
+								.sort((a, b) => a.node.name.localeCompare(b.node.name))
+								.map((nr) => (
+									<span
+										key={nr.node.id}
+										className={
+											nr.success ? styles.flushNodeOk : styles.flushNodeErr
+										}
+										title={nr.error || undefined}
+									>
+										{nr.success ? '✓' : '✗'} {nr.node.name}
+										{!nr.success && nr.error && (
+											<span className={styles.flushNodeErrMsg}>
+												{' '}
+												— {nr.error}
+											</span>
+										)}
+									</span>
+								))}
+						</div>
+					)}
+					<div className={styles.quickAction}>
+						<div className={styles.quickActionInfo}>
+							<span className={styles.quickActionLabel}>Restart DNS</span>
+							<span className={styles.quickActionDesc}>
+								Restart the FTL DNS resolver on all nodes. Use after
+								configuration changes that require a resolver reload.
+							</span>
+						</div>
+						<button
+							type='button'
+							className={styles.quickActionBtn}
+							onClick={handleRestartDNS}
+							disabled={restartSubmitting}
+							aria-busy={restartSubmitting}
+						>
+							{restartSubmitting ? (
+								<Loader2 size={16} className={styles.spin} />
+							) : (
+								<RotateCcw size={16} />
+							)}
+							{restartSubmitting ? 'Restarting…' : 'Restart DNS'}
+						</button>
+					</div>
+					{restartError && <p className={styles.error}>{restartError}</p>}
+					{restartResult && (
+						<div className={styles.flushResults} role='status' aria-live='polite'>
+							{Object.values(restartResult.nodes)
 								.sort((a, b) => a.node.name.localeCompare(b.node.name))
 								.map((nr) => (
 									<span

--- a/frontend/src/pages/Blocking/Blocking.tsx
+++ b/frontend/src/pages/Blocking/Blocking.tsx
@@ -593,20 +593,20 @@ export function Blocking() {
 					</div>
 					{flushError && <p className={styles.error}>{flushError}</p>}
 					{flushResult && (
-						<div className={styles.flushResults} role='status' aria-live='polite'>
+						<div className={styles.actionResults} role='status' aria-live='polite'>
 							{Object.values(flushResult.nodes)
 								.sort((a, b) => a.node.name.localeCompare(b.node.name))
 								.map((nr) => (
 									<span
 										key={nr.node.id}
 										className={
-											nr.success ? styles.flushNodeOk : styles.flushNodeErr
+											nr.success ? styles.actionNodeOk : styles.actionNodeErr
 										}
 										title={nr.error || undefined}
 									>
 										{nr.success ? '✓' : '✗'} {nr.node.name}
 										{!nr.success && nr.error && (
-											<span className={styles.flushNodeErrMsg}>
+											<span className={styles.actionNodeErrMsg}>
 												{' '}
 												— {nr.error}
 											</span>
@@ -640,20 +640,20 @@ export function Blocking() {
 					</div>
 					{restartError && <p className={styles.error}>{restartError}</p>}
 					{restartResult && (
-						<div className={styles.flushResults} role='status' aria-live='polite'>
+						<div className={styles.actionResults} role='status' aria-live='polite'>
 							{Object.values(restartResult.nodes)
 								.sort((a, b) => a.node.name.localeCompare(b.node.name))
 								.map((nr) => (
 									<span
 										key={nr.node.id}
 										className={
-											nr.success ? styles.flushNodeOk : styles.flushNodeErr
+											nr.success ? styles.actionNodeOk : styles.actionNodeErr
 										}
 										title={nr.error || undefined}
 									>
 										{nr.success ? '✓' : '✗'} {nr.node.name}
 										{!nr.success && nr.error && (
-											<span className={styles.flushNodeErrMsg}>
+											<span className={styles.actionNodeErrMsg}>
 												{' '}
 												— {nr.error}
 											</span>


### PR DESCRIPTION
## Summary

- New **Restart DNS** row in the existing Quick Actions section on the Blocking page
- Fans out `POST /api/action/restartDNS` to all cluster nodes concurrently (10s per-node timeout)
- Per-node success/failure badges appear inline after the action completes; auto-clear after 5 seconds
- No audit log entry — stateless/transient, same rationale as Flush Cache

## Changes

**Backend:**
- `pihole.Client.RestartDNS` — calls `POST /action/restartDNS`, drains body, checks HTTP 200
- `pihole.Cluster.RestartDNS` — fan-out with 10s timeout (cache flush uses 5s; restart takes slightly longer)
- `ClusterBlockingService.RestartDNS` — thin delegation
- `POST /api/v1/cluster/blocking/restart-dns` handler + response DTO (same shape as flush cache)

**Frontend:**
- `restartDNS()` + `RestartDNSResult` / `RestartDNSNodeResult` types in `lib/api/blocking.ts`
- Second Quick Action row in `Blocking.tsx` with `RotateCcw` icon, spinner, per-node results
- Adjacent sibling selector (`.quickAction + .quickAction`) in SCSS for row separator — no inline styles

## Test plan

- [ ] Navigate to `/blocking`; verify "Restart DNS" row appears below "Flush DNS Cache" in Quick Actions
- [ ] Click Restart DNS; spinner shows during request, then per-node results appear
- [ ] Results auto-clear after 5 seconds
- [ ] Button is disabled while request is in-flight
- [ ] Network error shows error message that auto-clears after 5 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)