### PR TITLE
feat: node version and gravity info on Home dashboard

### DIFF
--- a/backend/internal/domain/health.go
+++ b/backend/internal/domain/health.go
@@ -14,11 +14,23 @@ type ClusterHealthSummary struct {
 }
 
 type ClusterNodeHealth struct {
-	Id      int64
-	Name    string
-	Status  ClusterHealthStatus
-	Latency time.Duration
-	LastErr string
+	Id          int64
+	Name        string
+	Status      ClusterHealthStatus
+	Latency     time.Duration
+	LastErr     string
+	VersionInfo *NodeVersionInfo
+	DBInfo      *NodeDBInfo
+}
+
+type NodeVersionInfo struct {
+	PiholeVersion string
+	FTLVersion    string
+}
+
+type NodeDBInfo struct {
+	GravityCount     int64
+	GravityUpdatedAt *time.Time
 }
 
 type ClusterHealthStatus string

--- a/backend/internal/http/api/v1/cluster_health_dto.go
+++ b/backend/internal/http/api/v1/cluster_health_dto.go
@@ -15,11 +15,15 @@ type clusterHealthSummaryDTO struct {
 }
 
 type clusterNodeHealthDTO struct {
-	Id        int64  `json:"id"`
-	Name      string `json:"name"`
-	Status    string `json:"status"`
-	LatencyMS int    `json:"latencyMs"`
-	LastErr   string `json:"lastErr,omitempty"`
+	Id               int64  `json:"id"`
+	Name             string `json:"name"`
+	Status           string `json:"status"`
+	LatencyMS        int    `json:"latencyMs"`
+	LastErr          string `json:"lastErr,omitempty"`
+	PiholeVersion    string `json:"piholeVersion,omitempty"`
+	FTLVersion       string `json:"ftlVersion,omitempty"`
+	GravityCount     *int64 `json:"gravityCount,omitempty"`
+	GravityUpdatedAt *int64 `json:"gravityUpdatedAt,omitempty"`
 }
 
 func fromDomainToClusterHealthDTO(d domain.ClusterHealth) clusterHealthDTO {
@@ -32,13 +36,25 @@ func fromDomainToClusterHealthDTO(d domain.ClusterHealth) clusterHealthDTO {
 	}
 
 	for id, n := range d.Nodes {
-		dto.Nodes[id] = clusterNodeHealthDTO{
+		node := clusterNodeHealthDTO{
 			Id:        n.Id,
 			Name:      n.Name,
 			Status:    string(n.Status),
 			LatencyMS: int(n.Latency.Milliseconds()),
 			LastErr:   n.LastErr,
 		}
+		if n.VersionInfo != nil {
+			node.PiholeVersion = n.VersionInfo.PiholeVersion
+			node.FTLVersion = n.VersionInfo.FTLVersion
+		}
+		if n.DBInfo != nil {
+			node.GravityCount = &n.DBInfo.GravityCount
+			if n.DBInfo.GravityUpdatedAt != nil {
+				v := n.DBInfo.GravityUpdatedAt.Unix()
+				node.GravityUpdatedAt = &v
+			}
+		}
+		dto.Nodes[id] = node
 	}
 
 	return dto

--- a/backend/internal/pihole/client.go
+++ b/backend/internal/pihole/client.go
@@ -1111,6 +1111,45 @@ func (c *Client) RestartDNS(ctx context.Context) error {
 	return nil
 }
 
+func (c *Client) GetVersionInfo(ctx context.Context) (*domain.NodeVersionInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.getBaseURL()+"/info/version", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("getting version: %w", err)
+	}
+	defer resp.Body.Close()
+	var w versionWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding version: %w", err)
+	}
+	return &domain.NodeVersionInfo{PiholeVersion: w.Version.Tag, FTLVersion: w.FTL.Tag}, nil
+}
+
+func (c *Client) GetDatabaseInfo(ctx context.Context) (*domain.NodeDBInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.getBaseURL()+"/info/database", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("getting database info: %w", err)
+	}
+	defer resp.Body.Close()
+	var w databaseInfoWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, fmt.Errorf("decoding database info: %w", err)
+	}
+	info := &domain.NodeDBInfo{GravityCount: w.Gravity.Size}
+	if w.Gravity.Updated > 0 {
+		t := time.Unix(w.Gravity.Updated, 0)
+		info.GravityUpdatedAt = &t
+	}
+	return info, nil
+}
+
 func (c *Client) FlushCache(ctx context.Context) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.getBaseURL()+"/action/flush/cache", nil)
 	if err != nil {

--- a/backend/internal/pihole/cluster.go
+++ b/backend/internal/pihole/cluster.go
@@ -482,6 +482,20 @@ func (c *Cluster) AuthStatus(ctx context.Context) map[int64]*domain.NodeResult[*
 	return out
 }
 
+func (c *Cluster) GetVersionInfo(ctx context.Context) map[int64]*domain.NodeResult[*domain.NodeVersionInfo] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.NodeVersionInfo, error) {
+		return client.GetVersionInfo(nodeCtx)
+	})
+	return out
+}
+
+func (c *Cluster) GetDatabaseInfo(ctx context.Context) map[int64]*domain.NodeResult[*domain.NodeDBInfo] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.NodeDBInfo, error) {
+		return client.GetDatabaseInfo(nodeCtx)
+	})
+	return out
+}
+
 func (c *Cluster) Logout(ctx context.Context) map[int64]*domain.NodeResult[struct{}] {
 	c.logger.Debug().Msg("logging out all pihole nodes")
 	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (struct{}, error) {

--- a/backend/internal/pihole/interface.go
+++ b/backend/internal/pihole/interface.go
@@ -28,6 +28,8 @@ type clientPort interface {
 	RebuildGravity(ctx context.Context) error
 	FlushCache(ctx context.Context) error
 	RestartDNS(ctx context.Context) error
+	GetVersionInfo(ctx context.Context) (*domain.NodeVersionInfo, error)
+	GetDatabaseInfo(ctx context.Context) (*domain.NodeDBInfo, error)
 	AuthStatus(ctx context.Context) (*domain.AuthStatus, error)
 	Logout(ctx context.Context) error
 	GetStatsSummary(ctx context.Context) (*domain.StatsSummary, error)

--- a/backend/internal/pihole/wire.go
+++ b/backend/internal/pihole/wire.go
@@ -139,6 +139,24 @@ type domainWireInfo struct {
 	DateModified int64   `json:"date_modified"`
 }
 
+// Info
+
+type versionWireResponse struct {
+	Version struct {
+		Tag string `json:"tag"`
+	} `json:"version"`
+	FTL struct {
+		Tag string `json:"tag"`
+	} `json:"ftl"`
+}
+
+type databaseInfoWireResponse struct {
+	Gravity struct {
+		Size    int64 `json:"size"`
+		Updated int64 `json:"updated"`
+	} `json:"gravity"`
+}
+
 // Stats
 
 type statsSummaryWireResponse struct {

--- a/backend/internal/service/health/interface.go
+++ b/backend/internal/service/health/interface.go
@@ -14,4 +14,6 @@ type broker interface {
 
 type cluster interface {
 	AuthStatus(ctx context.Context) map[int64]*domain.NodeResult[*domain.AuthStatus]
+	GetVersionInfo(ctx context.Context) map[int64]*domain.NodeResult[*domain.NodeVersionInfo]
+	GetDatabaseInfo(ctx context.Context) map[int64]*domain.NodeResult[*domain.NodeDBInfo]
 }

--- a/backend/internal/service/health/service.go
+++ b/backend/internal/service/health/service.go
@@ -2,6 +2,7 @@ package healthsvc
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/auto-dns/pihole-cluster-admin/internal/config"
@@ -29,18 +30,25 @@ func NewService(broker broker, cluster cluster, cfg config.PublisherConfig, logg
 }
 
 func (s *Service) GetClusterHealth(ctx context.Context) domain.ClusterHealth {
-	nodes := s.cluster.AuthStatus(ctx)
+	var (
+		authNodes    map[int64]*domain.NodeResult[*domain.AuthStatus]
+		versionNodes map[int64]*domain.NodeResult[*domain.NodeVersionInfo]
+		dbNodes      map[int64]*domain.NodeResult[*domain.NodeDBInfo]
+	)
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() { defer wg.Done(); authNodes = s.cluster.AuthStatus(ctx) }()
+	go func() { defer wg.Done(); versionNodes = s.cluster.GetVersionInfo(ctx) }()
+	go func() { defer wg.Done(); dbNodes = s.cluster.GetDatabaseInfo(ctx) }()
+	wg.Wait()
 
 	res := domain.ClusterHealth{
-		Summary: domain.ClusterHealthSummary{
-			Online: 0,
-			Total:  0,
-		},
-		Nodes:     make(map[int64]domain.ClusterNodeHealth, len(nodes)),
+		Summary:   domain.ClusterHealthSummary{},
+		Nodes:     make(map[int64]domain.ClusterNodeHealth, len(authNodes)),
 		UpdatedAt: time.Now(),
 	}
 
-	for id, n := range nodes {
+	for id, n := range authNodes {
 		var tookMs int
 		var valid bool
 
@@ -57,6 +65,12 @@ func (s *Service) GetClusterHealth(ctx context.Context) domain.ClusterHealth {
 		}
 		if n.Error != nil {
 			nodeHealth.LastErr = n.Error.Error()
+		}
+		if v, ok := versionNodes[id]; ok && v.Success {
+			nodeHealth.VersionInfo = v.Response
+		}
+		if d, ok := dbNodes[id]; ok && d.Success {
+			nodeHealth.DBInfo = d.Response
 		}
 
 		res.Summary.Total++

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import { getBlockingDisplayState } from '@/utils/blockingStatus';
 import { PiholeStatusLight } from '@/components/StatusLight/PiholeStatusLight';
 import { getStatsSummary } from '@/lib/api/stats';
 import type { StatsSummaryResponse } from '@/types/stats';
-import { formatCount } from '@/utils/formatters';
+import { formatCount, formatRelativeTime } from '@/utils/formatters';
 import styles from './Home.module.scss';
 
 export function Home() {
@@ -131,6 +131,30 @@ export function Home() {
 										<dd>
 											{health?.latencyMs != null
 												? `${health.latencyMs}ms`
+												: '—'}
+										</dd>
+									</div>
+									<div className={styles.nodeDetail}>
+										<dt>Pi-hole</dt>
+										<dd>{health?.piholeVersion ?? '—'}</dd>
+									</div>
+									<div className={styles.nodeDetail}>
+										<dt>FTL</dt>
+										<dd>{health?.ftlVersion ?? '—'}</dd>
+									</div>
+									<div className={styles.nodeDetail}>
+										<dt>Gravity</dt>
+										<dd>
+											{health?.gravityCount != null
+												? formatCount(health.gravityCount)
+												: '—'}
+										</dd>
+									</div>
+									<div className={styles.nodeDetail}>
+										<dt>Updated</dt>
+										<dd>
+											{health?.gravityUpdatedAt != null
+												? formatRelativeTime(health.gravityUpdatedAt)
 												: '—'}
 										</dd>
 									</div>

--- a/frontend/src/types/health.ts
+++ b/frontend/src/types/health.ts
@@ -14,6 +14,10 @@ export type NodeHealth = {
 	status: NodeStatus;
 	latencyMs: number;
 	lastErr?: string;
+	piholeVersion?: string;
+	ftlVersion?: string;
+	gravityCount?: number;
+	gravityUpdatedAt?: number; // unix timestamp (seconds)
 };
 
 export const NodeStatus = {

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -3,3 +3,13 @@ export function formatCount(n: number): string {
 	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
 	return String(n);
 }
+
+export function formatRelativeTime(unixSeconds: number): string {
+	const elapsed = Math.floor(Date.now() / 1000) - unixSeconds;
+	if (elapsed < 60) return 'just now';
+	if (elapsed < 3600) return `${Math.floor(elapsed / 60)} min ago`;
+	if (elapsed < 86400) return `${Math.floor(elapsed / 3600)} hr ago`;
+	if (elapsed < 86400 * 30) return `${Math.floor(elapsed / 86400)} days ago`;
+	if (elapsed < 86400 * 365) return `${Math.floor(elapsed / (86400 * 30))} mo ago`;
+	return `${Math.floor(elapsed / (86400 * 365))} yr ago`;
+}


### PR DESCRIPTION
## Summary

- Home dashboard node cards now show **Pi-hole version**, **FTL version**, **Gravity domain count**, and **Last gravity update** alongside existing Status and Latency
- Extends the health poll to fan out `GET /api/info/version` and `GET /api/info/database` alongside the existing `AuthStatus` call — all three run concurrently via `sync.WaitGroup`
- Version/gravity data flows through the existing SSE health stream — no new endpoints or wiring needed on the frontend
- Fields are optional: if a node is offline or either call fails, the UI shows "—" gracefully

## Changes

**Backend:**
- `domain/health.go` — new `NodeVersionInfo` + `NodeDBInfo` types; `ClusterNodeHealth` extended with optional pointers to both
- `pihole/wire.go` — `versionWireResponse` + `databaseInfoWireResponse` wire types
- `pihole/client.go` — `GetVersionInfo` (GET `/info/version`) + `GetDatabaseInfo` (GET `/info/database`)
- `pihole/cluster.go` — fan-out methods for both (3s timeout each)
- `service/health/` — parallel fan-outs with `sync.WaitGroup`; results merged into `ClusterNodeHealth`
- `cluster_health_dto.go` — four new optional fields in `clusterNodeHealthDTO`

**Frontend:**
- `types/health.ts` — four new optional fields on `NodeHealth`
- `utils/formatters.ts` — new `formatRelativeTime(unixSeconds)` helper
- `pages/Home.tsx` — four new `<dt>`/`<dd>` rows in each node card

## Test plan

- [ ] Navigate to `/`; verify node cards show Pi-hole version, FTL version, Gravity count, Last updated
- [ ] Values show "—" gracefully when a node is offline
- [ ] Gravity "Updated" shows relative time (e.g. "3 days ago")
- [ ] Verify wire JSON keys match actual Pi-hole v6 API responses for `/api/info/version` and `/api/info/database`

🤖 Generated with [Claude Code](https://claude.com/claude-code)