### PR TITLE
fix: correct Pi-hole API wire types for version and gravity info

### DIFF
--- a/backend/internal/pihole/client.go
+++ b/backend/internal/pihole/client.go
@@ -1125,26 +1125,29 @@ func (c *Client) GetVersionInfo(ctx context.Context) (*domain.NodeVersionInfo, e
 	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
 		return nil, fmt.Errorf("decoding version: %w", err)
 	}
-	return &domain.NodeVersionInfo{PiholeVersion: w.Version.Tag, FTLVersion: w.FTL.Tag}, nil
+	return &domain.NodeVersionInfo{
+		PiholeVersion: w.Version.Core.Local.Version,
+		FTLVersion:    w.Version.FTL.Local.Version,
+	}, nil
 }
 
 func (c *Client) GetDatabaseInfo(ctx context.Context) (*domain.NodeDBInfo, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.getBaseURL()+"/info/database", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.getBaseURL()+"/stats/summary", nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	resp, err := c.doRequest(req)
 	if err != nil {
-		return nil, fmt.Errorf("getting database info: %w", err)
+		return nil, fmt.Errorf("getting gravity info: %w", err)
 	}
 	defer resp.Body.Close()
-	var w databaseInfoWireResponse
+	var w gravityInfoWireResponse
 	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
-		return nil, fmt.Errorf("decoding database info: %w", err)
+		return nil, fmt.Errorf("decoding gravity info: %w", err)
 	}
-	info := &domain.NodeDBInfo{GravityCount: w.Gravity.Size}
-	if w.Gravity.Updated > 0 {
-		t := time.Unix(w.Gravity.Updated, 0)
+	info := &domain.NodeDBInfo{GravityCount: w.Gravity.DomainsBeingBlocked}
+	if w.Gravity.LastUpdate > 0 {
+		t := time.Unix(w.Gravity.LastUpdate, 0)
 		info.GravityUpdatedAt = &t
 	}
 	return info, nil

--- a/backend/internal/pihole/wire.go
+++ b/backend/internal/pihole/wire.go
@@ -143,17 +143,23 @@ type domainWireInfo struct {
 
 type versionWireResponse struct {
 	Version struct {
-		Tag string `json:"tag"`
+		Core struct {
+			Local struct {
+				Version string `json:"version"`
+			} `json:"local"`
+		} `json:"core"`
+		FTL struct {
+			Local struct {
+				Version string `json:"version"`
+			} `json:"local"`
+		} `json:"ftl"`
 	} `json:"version"`
-	FTL struct {
-		Tag string `json:"tag"`
-	} `json:"ftl"`
 }
 
-type databaseInfoWireResponse struct {
+type gravityInfoWireResponse struct {
 	Gravity struct {
-		Size    int64 `json:"size"`
-		Updated int64 `json:"updated"`
+		DomainsBeingBlocked int64 `json:"domains_being_blocked"`
+		LastUpdate          int64 `json:"last_update"`
 	} `json:"gravity"`
 }
 

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -9,7 +9,7 @@ export function formatRelativeTime(unixSeconds: number): string {
 	if (elapsed < 60) return 'just now';
 	if (elapsed < 3600) return `${Math.floor(elapsed / 60)} min ago`;
 	if (elapsed < 86400) return `${Math.floor(elapsed / 3600)} hr ago`;
-	if (elapsed < 86400 * 30) return `${Math.floor(elapsed / 86400)} days ago`;
+	if (elapsed < 86400 * 30) { const d = Math.floor(elapsed / 86400); return `${d} ${d === 1 ? 'day' : 'days'} ago`; }
 	if (elapsed < 86400 * 365) return `${Math.floor(elapsed / (86400 * 30))} mo ago`;
 	return `${Math.floor(elapsed / (86400 * 365))} yr ago`;
 }


### PR DESCRIPTION
## Summary

- **`versionWireResponse`** was wrong — `/api/info/version` returns a nested structure; the Pi-hole and FTL versions are at `version.core.local.version` and `version.ftl.local.version`, not `version.tag`/`ftl.tag`
- **`GetDatabaseInfo` was calling the wrong endpoint** — `/api/info/database` returns FTL query-log database file stats (size, permissions, timestamps). Gravity count and last-update timestamp are in `/api/stats/summary` under `gravity.domains_being_blocked` and `gravity.last_update`. Updated endpoint and renamed wire type to `gravityInfoWireResponse`
- **`formatRelativeTime`** — fixed "1 days ago" → "1 day ago" (singular guard)

Verified against FTL source: `src/api/info.c` (`api_info_version`, `get_version_obj`) and `src/api/stats.c` (`api_stats_summary`).

## Test plan

- [ ] Navigate to `/`; node cards show Pi-hole version, FTL version, gravity count, and relative gravity update time
- [ ] Gravity "Updated" field shows correct relative time instead of "—"
- [ ] "1 day ago" shown correctly (not "1 days ago") when gravity was updated yesterday

🤖 Generated with [Claude Code](https://claude.com/claude-code)