### PR TITLE
feat: per-client drilldown from Stats to Query Logs

### DIFF
--- a/frontend/src/pages/QueryLogs.tsx
+++ b/frontend/src/pages/QueryLogs.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, Fragment, useMemo } from 'react';
+import { useSearchParams } from 'react-router';
 import { Search, RefreshCw, Shield, ShieldOff, Plus, Minus } from 'lucide-react';
 import { getQueryLogs, type QueryLogParams } from '@/lib/api/logs';
 import { addDomainRule } from '@/lib/api/domainrules';
@@ -54,9 +55,12 @@ const QTYPE_OPTIONS = [
 ];
 
 export function QueryLogs() {
+	const [searchParams] = useSearchParams();
+	const initialClientIp = useRef(searchParams.get('client') ?? '').current;
+
 	const [timePreset, setTimePreset] = useState<TimePreset>('5m');
 	const [domain, setDomain] = useState('');
-	const [clientIp, setClientIp] = useState('');
+	const [clientIp, setClientIp] = useState(initialClientIp);
 
 	// Client-side filters
 	const [statusFilter, setStatusFilter] = useState('');
@@ -179,9 +183,9 @@ export function QueryLogs() {
 	);
 
 	useEffect(() => {
-		appliedFilters.current = { timePreset: INITIAL_PRESET, domain: '', clientIp: '' };
-		fetchLogs({ timePreset: INITIAL_PRESET, domain: '', clientIp: '' });
-	}, [fetchLogs]);
+		appliedFilters.current = { timePreset: INITIAL_PRESET, domain: '', clientIp: initialClientIp };
+		fetchLogs({ timePreset: INITIAL_PRESET, domain: '', clientIp: initialClientIp });
+	}, [fetchLogs, initialClientIp]);
 
 	function handlePreset(preset: TimePreset) {
 		setTimePreset(preset);

--- a/frontend/src/pages/Stats.module.scss
+++ b/frontend/src/pages/Stats.module.scss
@@ -265,9 +265,15 @@
 	text-decoration: none;
 	color: inherit;
 
+	.clientName {
+		text-decoration: underline;
+		text-decoration-color: var(--border-primary);
+		text-underline-offset: 2px;
+	}
+
 	&:hover .clientName {
 		color: var(--accent-primary);
-		text-decoration: underline;
+		text-decoration-color: var(--accent-primary);
 	}
 }
 

--- a/frontend/src/pages/Stats.module.scss
+++ b/frontend/src/pages/Stats.module.scss
@@ -260,6 +260,17 @@
 	word-break: break-all;
 }
 
+.clientLink {
+	display: block;
+	text-decoration: none;
+	color: inherit;
+
+	&:hover .clientName {
+		color: var(--accent-primary);
+		text-decoration: underline;
+	}
+}
+
 .clientName {
 	display: block;
 	font-weight: 500;

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router';
 import {
 	LineChart,
 	Line,
@@ -372,10 +373,15 @@ export function Stats() {
 									(topClients?.clusterClients ?? []).map((c) => (
 										<tr key={c.ip}>
 											<td>
-												<span className={styles.clientName}>{c.name || c.ip}</span>
-												{c.name && (
-													<span className={styles.clientIp}>{c.ip}</span>
-												)}
+												<Link
+													to={`/query?client=${encodeURIComponent(c.ip)}`}
+													className={styles.clientLink}
+												>
+													<span className={styles.clientName}>{c.name || c.ip}</span>
+													{c.name && (
+														<span className={styles.clientIp}>{c.ip}</span>
+													)}
+												</Link>
 											</td>
 											<td className={styles.countCol}>{formatCount(c.count)}</td>
 										</tr>


### PR DESCRIPTION
## Summary

- Client rows in Stats > Top Clients are now clickable links navigating to `/query?client=<ip>`
- Query Logs reads the `?client=` URL param on mount, pre-fills the Client IP filter, and runs the initial fetch with it
- Link styling: inherits table text color, underlines the client name on hover via `var(--accent-primary)`

## Files changed

- `Stats.tsx` — wrap client cell in `<Link to="/query?client=…">`
- `Stats.module.scss` — add `.clientLink` (block, no underline, hover accent)
- `QueryLogs.tsx` — read `?client=` via `useSearchParams`, init state + first fetch from it

## Test plan

- [ ] Navigate to Stats > Top Clients; confirm cursor changes on hover and name underlines in accent color
- [ ] Click a client; confirm navigation to `/query?client=<ip>` with Client IP field pre-filled and results already loaded for that client
- [ ] Navigate to `/query` directly (no param); confirm normal empty-filter behavior unchanged
- [ ] Navigate to `/query?client=192.168.1.x` directly; confirm pre-fill and fetch work on hard reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)