### PR TITLE
feat: regex rule tester on Domains page

### DIFF
--- a/backend/internal/domain/domainrule.go
+++ b/backend/internal/domain/domainrule.go
@@ -88,3 +88,15 @@ type SyncDomainRuleNodeResult struct {
 	AlreadyPresent bool
 	Added          bool
 }
+
+type RegexMatch struct {
+	ID      int
+	Pattern string
+	Kind    string // "deny" | "allow"
+	Enabled bool
+}
+
+type RegexTestResult struct {
+	Domain  string
+	Matches []RegexMatch
+}

--- a/backend/internal/http/api/v1/domainrule_dto.go
+++ b/backend/internal/http/api/v1/domainrule_dto.go
@@ -143,6 +143,32 @@ type syncDomainRuleNodeDTO struct {
 	Error          string           `json:"error,omitempty"`
 }
 
+// Regex test
+
+type regexTestRequestDTO struct {
+	Domain string `json:"domain"`
+}
+
+type regexTestResponseDTO struct {
+	Domain string             `json:"domain"`
+	Nodes  []regexTestNodeDTO `json:"nodes"`
+}
+
+type regexTestNodeDTO struct {
+	NodeId   int64           `json:"nodeId"`
+	NodeName string          `json:"nodeName"`
+	Success  bool            `json:"success"`
+	Error    string          `json:"error,omitempty"`
+	Matches  []regexMatchDTO `json:"matches"`
+}
+
+type regexMatchDTO struct {
+	ID      int    `json:"id"`
+	Pattern string `json:"pattern"`
+	Kind    string `json:"kind"`
+	Enabled bool   `json:"enabled"`
+}
+
 // Remove domain
 
 type removeDomainRuleResponseDTO struct {

--- a/backend/internal/http/api/v1/domainrule_handlers.go
+++ b/backend/internal/http/api/v1/domainrule_handlers.go
@@ -25,6 +25,8 @@ func registerDomainRules(r chi.Router, d Deps) {
 		r.Delete("/type/{type}/kind/{kind}/domain/{domain}", domainRuleRemoveDomainRule(d))
 		// Parity sync
 		r.Post("/parity/sync", domainRuleSyncParityRule(d))
+		// Regex tester
+		r.Post("/regex/test", domainRuleTestRegex(d))
 	})
 }
 
@@ -336,6 +338,51 @@ func domainRuleSyncParityRule(d Deps) http.HandlerFunc {
 			default:
 				dto.Summary.FailedNodes++
 			}
+		}
+
+		transport.WriteJSON(w, http.StatusOK, dto)
+	}
+}
+
+func domainRuleTestRegex(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body regexTestRequestDTO
+		if err := transport.DecodeJSONBody(w, r, &body, 1<<20); err != nil {
+			transport.WriteErr(w, err)
+			return
+		}
+		if body.Domain == "" {
+			transport.WriteBadRequestErr(w, "\"domain\" is required", errors.New("\"domain\" is required"))
+			return
+		}
+
+		results := d.DomainRuleService.TestRegex(r.Context(), body.Domain)
+
+		dto := regexTestResponseDTO{
+			Domain: body.Domain,
+			Nodes:  make([]regexTestNodeDTO, 0, len(results)),
+		}
+		for _, nr := range results {
+			node := regexTestNodeDTO{
+				NodeId:   nr.PiholeNode.Id,
+				NodeName: nr.PiholeNode.Name,
+				Success:  nr.Success,
+				Matches:  make([]regexMatchDTO, 0),
+			}
+			if nr.Error != nil {
+				node.Error = nr.Error.Error()
+			}
+			if nr.Success && nr.Response != nil {
+				for _, m := range nr.Response.Matches {
+					node.Matches = append(node.Matches, regexMatchDTO{
+						ID:      m.ID,
+						Pattern: m.Pattern,
+						Kind:    m.Kind,
+						Enabled: m.Enabled,
+					})
+				}
+			}
+			dto.Nodes = append(dto.Nodes, node)
 		}
 
 		transport.WriteJSON(w, http.StatusOK, dto)

--- a/backend/internal/http/api/v1/domainrule_handlers.go
+++ b/backend/internal/http/api/v1/domainrule_handlers.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
 	"github.com/auto-dns/pihole-cluster-admin/internal/http/transport"
@@ -351,15 +352,16 @@ func domainRuleTestRegex(d Deps) http.HandlerFunc {
 			transport.WriteErr(w, err)
 			return
 		}
-		if body.Domain == "" {
+		testDomain := strings.TrimSpace(body.Domain)
+		if testDomain == "" {
 			transport.WriteBadRequestErr(w, "\"domain\" is required", errors.New("\"domain\" is required"))
 			return
 		}
 
-		results := d.DomainRuleService.TestRegex(r.Context(), body.Domain)
+		results := d.DomainRuleService.TestRegex(r.Context(), testDomain)
 
 		dto := regexTestResponseDTO{
-			Domain: body.Domain,
+			Domain: testDomain,
 			Nodes:  make([]regexTestNodeDTO, 0, len(results)),
 		}
 		for _, nr := range results {

--- a/backend/internal/http/api/v1/interface.go
+++ b/backend/internal/http/api/v1/interface.go
@@ -56,6 +56,7 @@ type domainRuleService interface {
 	Add(ctx context.Context, cmd domain.AddDomainRulesCommand) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult]
 	Remove(ctx context.Context, cmd domain.RemoveDomainRuleCommand) map[int64]*domain.NodeResult[struct{}]
 	SyncRule(ctx context.Context, cmd domain.SyncDomainRuleCommand) map[int64]*domain.NodeResult[*domain.SyncDomainRuleNodeResult]
+	TestRegex(ctx context.Context, testDomain string) map[int64]*domain.NodeResult[*domain.RegexTestResult]
 }
 
 type healthService interface {

--- a/backend/internal/pihole/client.go
+++ b/backend/internal/pihole/client.go
@@ -1433,6 +1433,44 @@ func (c *Client) RemovePiholeClient(ctx context.Context, cmd domain.RemovePihole
 	return nil
 }
 
+func (c *Client) TestRegex(ctx context.Context, testDomain string) (*domain.RegexTestResult, error) {
+	body, err := json.Marshal(regexTestWireRequest{Domain: testDomain})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.getBaseURL()+"/regex/test", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("testing regex: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var wireResp domainsWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wireResp); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	result := &domain.RegexTestResult{Domain: testDomain}
+	for _, d := range wireResp.Domains {
+		result.Matches = append(result.Matches, domain.RegexMatch{
+			ID:      d.Id,
+			Pattern: d.Domain,
+			Kind:    d.Type,
+			Enabled: d.Enabled,
+		})
+	}
+	return result, nil
+}
+
 func (c *Client) logoutWithSID(ctx context.Context, sid string) error {
 	if sid == "" {
 		return nil

--- a/backend/internal/pihole/cluster.go
+++ b/backend/internal/pihole/cluster.go
@@ -504,6 +504,13 @@ func (c *Cluster) Logout(ctx context.Context) map[int64]*domain.NodeResult[struc
 	return out
 }
 
+func (c *Cluster) TestRegex(ctx context.Context, testDomain string) map[int64]*domain.NodeResult[*domain.RegexTestResult] {
+	out, _ := fanout(c, ctx, 0, 3*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.RegexTestResult, error) {
+		return client.TestRegex(nodeCtx, testDomain)
+	})
+	return out
+}
+
 func (c *Cluster) SetPasswordForNode(ctx context.Context, nodeID int64, newPassword string) error {
 	c.rw.RLock()
 	client, exists := c.clients[nodeID]

--- a/backend/internal/pihole/interface.go
+++ b/backend/internal/pihole/interface.go
@@ -44,6 +44,7 @@ type clientPort interface {
 	UpdatePiholeClient(ctx context.Context, cmd domain.UpdatePiholeClientCommand) (*domain.PiholeClientSet, error)
 	RemovePiholeClient(ctx context.Context, cmd domain.RemovePiholeClientCommand) error
 	SetPassword(ctx context.Context, newPassword string) error
+	TestRegex(ctx context.Context, testDomain string) (*domain.RegexTestResult, error)
 }
 
 type cursorManagerPort[T any] interface {

--- a/backend/internal/pihole/wire.go
+++ b/backend/internal/pihole/wire.go
@@ -320,3 +320,7 @@ type addDomainsWireResponse struct {
 	} `json:"processed,omitempty"`
 	Took float64 `json:"took"`
 }
+
+type regexTestWireRequest struct {
+	Domain string `json:"domain"`
+}

--- a/backend/internal/service/domainrule/interface.go
+++ b/backend/internal/service/domainrule/interface.go
@@ -11,6 +11,7 @@ type cluster interface {
 	AddDomainRule(ctx context.Context, cmd domain.AddDomainRulesCommand) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult]
 	AddDomainRuleToNodes(ctx context.Context, cmd domain.AddDomainRulesCommand, nodeIDs []int64) map[int64]*domain.NodeResult[*domain.AddDomainRulesResult]
 	RemoveDomainRule(ctx context.Context, cmd domain.RemoveDomainRuleCommand) map[int64]*domain.NodeResult[struct{}]
+	TestRegex(ctx context.Context, testDomain string) map[int64]*domain.NodeResult[*domain.RegexTestResult]
 }
 
 type auditLogger interface {

--- a/backend/internal/service/domainrule/service.go
+++ b/backend/internal/service/domainrule/service.go
@@ -146,3 +146,7 @@ func (s *Service) SyncRule(ctx context.Context, cmd domain.SyncDomainRuleCommand
 
 	return out
 }
+
+func (s *Service) TestRegex(ctx context.Context, testDomain string) map[int64]*domain.NodeResult[*domain.RegexTestResult] {
+	return s.cluster.TestRegex(ctx, testDomain)
+}

--- a/frontend/src/lib/api/domainrules.ts
+++ b/frontend/src/lib/api/domainrules.ts
@@ -4,6 +4,7 @@ import type {
 	AddDomainRuleResponse,
 	RemoveDomainRuleResponse,
 	SyncDomainRuleResponse,
+	RegexTestResponse,
 	RuleType,
 	RuleKind,
 } from '@/types/domainrule';
@@ -49,5 +50,12 @@ export async function syncDomainRule(
 	return apiV1Fetch<SyncDomainRuleResponse>('/domain/parity/sync', {
 		method: 'POST',
 		body: JSON.stringify({ type, kind, domain, comment: comment || undefined }),
+	});
+}
+
+export async function testRegex(domain: string): Promise<RegexTestResponse> {
+	return apiV1Fetch<RegexTestResponse>('/domain/regex/test', {
+		method: 'POST',
+		body: JSON.stringify({ domain }),
 	});
 }

--- a/frontend/src/pages/Domains.module.scss
+++ b/frontend/src/pages/Domains.module.scss
@@ -93,6 +93,136 @@
 	}
 }
 
+// ---- Regex tester button (toolbar) ----
+
+.regexTesterBtn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.2rem;
+	height: 2.2rem;
+	padding: 0 !important;
+	background: var(--btn-surface-bg) !important;
+	color: var(--btn-surface-text) !important;
+	border: 1px solid var(--border-card);
+	border-radius: var(--input-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: var(--btn-surface-bg-hover) !important;
+	}
+}
+
+// ---- Regex tester panel ----
+
+.regexPanel {
+	background: var(--bg-card);
+	border: 1px solid var(--border-card);
+	border-radius: var(--card-radius);
+	padding: 0.75rem 1rem;
+	margin-bottom: 1rem;
+}
+
+.regexPanelRow {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+	flex-wrap: wrap;
+}
+
+.regexInput {
+	flex: 1;
+	min-width: 12rem;
+	padding: 0.35rem 0.6rem;
+	font-size: 0.875rem;
+	font-family: monospace;
+	background: var(--input-bg);
+	color: var(--text-primary);
+	border: 1px solid var(--border-card);
+	border-radius: var(--input-radius);
+
+	&:disabled {
+		opacity: 0.6;
+	}
+}
+
+.regexResults {
+	margin-top: 0.75rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.6rem;
+}
+
+.regexNodeResult {
+	font-size: 0.85rem;
+}
+
+.regexNodeName {
+	font-weight: 600;
+	margin-right: 0.5rem;
+}
+
+.regexNodeError {
+	color: var(--accent-danger);
+	font-size: 0.82rem;
+}
+
+.regexNoMatch {
+	color: var(--text-secondary);
+	font-style: italic;
+}
+
+.regexMatchList {
+	list-style: none;
+	margin: 0.25rem 0 0 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.regexMatchItem {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	flex-wrap: wrap;
+}
+
+.regexPattern {
+	font-family: monospace;
+	font-size: 0.82rem;
+	background: var(--bg-surface);
+	padding: 0.15rem 0.4rem;
+	border-radius: 3px;
+	word-break: break-all;
+}
+
+.regexKindBadge {
+	font-size: 0.72rem;
+	font-weight: 600;
+	padding: 0.1rem 0.4rem;
+	border-radius: 3px;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+
+	&[data-kind='deny'] {
+		background: color-mix(in oklab, var(--accent-danger) 15%, transparent);
+		color: var(--accent-danger);
+	}
+
+	&[data-kind='allow'] {
+		background: color-mix(in oklab, var(--accent-success) 15%, transparent);
+		color: var(--accent-success);
+	}
+}
+
+.regexDisabled {
+	font-size: 0.72rem;
+	color: var(--text-secondary);
+	font-style: italic;
+}
+
 // ---- Force-sync button (toolbar) ----
 
 .forceSyncBtn {

--- a/frontend/src/pages/Domains.tsx
+++ b/frontend/src/pages/Domains.tsx
@@ -530,7 +530,7 @@ export function Domains() {
 									) : (
 										<ul className={styles.regexMatchList}>
 											{node.matches.map((m) => (
-												<li key={m.id} className={styles.regexMatchItem}>
+												<li key={`${m.id}-${m.pattern}`} className={styles.regexMatchItem}>
 													<code className={styles.regexPattern}>{m.pattern}</code>
 													<span
 														className={styles.regexKindBadge}

--- a/frontend/src/pages/Domains.tsx
+++ b/frontend/src/pages/Domains.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Plus, Trash2, RefreshCw, X, GitMerge, CheckCircle, XCircle } from 'lucide-react';
+import { Plus, Trash2, RefreshCw, X, GitMerge, CheckCircle, XCircle, FlaskConical } from 'lucide-react';
 import {
 	listDomainRules,
 	addDomainRule,
 	removeDomainRule,
 	syncDomainRule,
+	testRegex,
 } from '@/lib/api/domainrules';
 import { listGroups } from '@/lib/api/groups';
 import { syncFromNode } from '@/lib/api/sync';
@@ -15,6 +16,7 @@ import type {
 	RuleType,
 	RuleKind,
 	ListDomainRulesResponse,
+	RegexTestResponse,
 } from '@/types/domainrule';
 import type { Group } from '@/types/group';
 import type { SyncNodeResult } from '@/types/sync';
@@ -88,6 +90,13 @@ export function Domains() {
 	const [syncingRule, setSyncingRule] = useState<string | null>(null);
 	const [syncingAll, setSyncingAll] = useState(false);
 	const [ruleSyncError, setRuleSyncError] = useState<string | null>(null);
+
+	// Regex tester
+	const [regexTesterOpen, setRegexTesterOpen] = useState(false);
+	const [regexInput, setRegexInput] = useState('');
+	const [regexTesting, setRegexTesting] = useState(false);
+	const [regexResult, setRegexResult] = useState<RegexTestResponse | null>(null);
+	const [regexError, setRegexError] = useState<string | null>(null);
 
 	// Force-sync (replicate one node's full rule set to all others)
 	const [forceSyncOpen, setForceSyncOpen] = useState(false);
@@ -210,6 +219,21 @@ export function Domains() {
 		}
 	}
 
+	async function handleTestRegex() {
+		if (!regexInput.trim()) return;
+		setRegexTesting(true);
+		setRegexError(null);
+		setRegexResult(null);
+		try {
+			const result = await testRegex(regexInput.trim());
+			setRegexResult(result);
+		} catch (err) {
+			setRegexError(err instanceof Error ? err.message : 'Test failed');
+		} finally {
+			setRegexTesting(false);
+		}
+	}
+
 	async function handleRemove(rule: ConsolidatedRule) {
 		setRemoveError(null);
 		setRemoving(rule.key);
@@ -254,6 +278,21 @@ export function Domains() {
 						aria-label='Refresh'
 					>
 						<RefreshCw size={16} className={loading ? styles.spin : undefined} />
+					</button>
+
+					<button
+						type='button'
+						className={styles.regexTesterBtn}
+						onClick={() => {
+							setRegexTesterOpen((v) => !v);
+							setRegexResult(null);
+							setRegexError(null);
+							setRegexInput('');
+						}}
+						aria-label='Test regex'
+						title='Test a domain against regex rules'
+					>
+						<FlaskConical size={16} />
 					</button>
 
 					{piholeNodes.length > 1 && (
@@ -440,6 +479,78 @@ export function Domains() {
 					</Dialog.Root>
 				</div>
 			</div>
+
+			{regexTesterOpen && (
+				<div className={styles.regexPanel}>
+					<div className={styles.regexPanelRow}>
+						<label htmlFor='regex-test-domain' className={styles.syncLabel}>
+							Test domain:
+						</label>
+						<input
+							id='regex-test-domain'
+							type='text'
+							className={styles.regexInput}
+							placeholder='e.g. ads.example.com'
+							value={regexInput}
+							onChange={(e) => {
+								setRegexInput(e.target.value);
+								setRegexResult(null);
+								setRegexError(null);
+							}}
+							onKeyDown={(e) => e.key === 'Enter' && handleTestRegex()}
+							disabled={regexTesting}
+						/>
+						<button
+							type='button'
+							className={styles.syncRunBtn}
+							onClick={handleTestRegex}
+							disabled={regexTesting || !regexInput.trim()}
+							aria-busy={regexTesting}
+						>
+							{regexTesting ? (
+								<RefreshCw size={14} className={styles.spin} />
+							) : (
+								<FlaskConical size={14} />
+							)}
+							{regexTesting ? 'Testing…' : 'Test'}
+						</button>
+					</div>
+					{regexError && (
+						<div className={styles.syncPanelError}>{regexError}</div>
+					)}
+					{regexResult && (
+						<div className={styles.regexResults}>
+							{regexResult.nodes.map((node) => (
+								<div key={node.nodeId} className={styles.regexNodeResult}>
+									<span className={styles.regexNodeName}>{node.nodeName}</span>
+									{!node.success ? (
+										<span className={styles.regexNodeError}>{node.error || 'Unavailable'}</span>
+									) : node.matches.length === 0 ? (
+										<span className={styles.regexNoMatch}>No match</span>
+									) : (
+										<ul className={styles.regexMatchList}>
+											{node.matches.map((m) => (
+												<li key={m.id} className={styles.regexMatchItem}>
+													<code className={styles.regexPattern}>{m.pattern}</code>
+													<span
+														className={styles.regexKindBadge}
+														data-kind={m.kind}
+													>
+														{m.kind === 'deny' ? 'Block' : 'Allow'}
+													</span>
+													{!m.enabled && (
+														<span className={styles.regexDisabled}>disabled</span>
+													)}
+												</li>
+											))}
+										</ul>
+									)}
+								</div>
+							))}
+						</div>
+					)}
+				</div>
+			)}
 
 			{forceSyncOpen && piholeNodes.length > 1 && (
 				<div className={styles.syncPanel}>

--- a/frontend/src/types/domainrule.ts
+++ b/frontend/src/types/domainrule.ts
@@ -81,6 +81,26 @@ export type ConsolidatedRule = {
 	totalNodes: number;
 };
 
+export type RegexMatch = {
+	id: number;
+	pattern: string;
+	kind: 'deny' | 'allow';
+	enabled: boolean;
+};
+
+export type RegexTestNodeResult = {
+	nodeId: number;
+	nodeName: string;
+	success: boolean;
+	error?: string;
+	matches: RegexMatch[];
+};
+
+export type RegexTestResponse = {
+	domain: string;
+	nodes: RegexTestNodeResult[];
+};
+
 export type SyncDomainRuleResponse = {
 	summary: {
 		totalNodes: number;


### PR DESCRIPTION
## Summary

- New test-tube button in the Domains page toolbar opens an inline regex tester panel
- Enter any domain and press Enter or click Test; request fans out to all cluster nodes via `POST /api/v1/domain/regex/test` (which calls Pi-hole's `POST /api/regex/test`)
- Per-node results: matched regex patterns, block/allow badge, disabled indicator; "No match" when nothing matches; error when node is unavailable

## Architecture

Full stack, thin-service pattern:

| Layer | Change |
|---|---|
| `domain/domainrule.go` | `RegexMatch`, `RegexTestResult` types |
| `pihole/wire.go` | `regexTestWireRequest` |
| `pihole/interface.go` + `client.go` | `TestRegex` — `POST /api/regex/test`, parses `domainsWireResponse` |
| `pihole/cluster.go` | `TestRegex` fan-out via generic `fanout` helper |
| `service/domainrule/interface.go` + `service.go` | `TestRegex` pass-through |
| `http/api/v1/interface.go` + `domainrule_dto.go` + `domainrule_handlers.go` | `POST /domain/regex/test` handler + DTOs |
| `types/domainrule.ts` + `lib/api/domainrules.ts` | `RegexTestResponse` type + `testRegex()` API fn |
| `pages/Domains.tsx` + `Domains.module.scss` | Toolbar button, inline panel, results UI |

## Notes

The Pi-hole `POST /api/regex/test` endpoint URL and response shape (`domainsWireResponse`) are inferred from FTL source patterns and may need adjustment after testing against live Pi-hole v6 nodes. If the endpoint URL is wrong, Pi-hole returns a non-200 and the error is surfaced per-node in the UI.

## Test plan

- [ ] Click the test-tube icon on the Domains page; panel expands
- [ ] Click again; panel collapses and state resets
- [ ] Type a domain that matches a regex rule and press Enter; results show the matching pattern, kind badge, and node name
- [ ] Type a domain that matches nothing; results show "No match" per node
- [ ] Verify panel works with 1 node and with multiple nodes (per-node rows)
- [ ] `go build ./...` and `go vet ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)