### PR TITLE
feat: Pi-hole config management via Settings page

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -22,6 +22,7 @@ import (
 	auditlogsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/auditlog"
 	authsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/auth"
 	clusterblockingsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/clusterblocking"
+	configsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/configsvc"
 	domainrulesvc "github.com/auto-dns/pihole-cluster-admin/internal/service/domainrule"
 	eventssvc "github.com/auto-dns/pihole-cluster-admin/internal/service/events"
 	groupsvc "github.com/auto-dns/pihole-cluster-admin/internal/service/groupsvc"
@@ -100,6 +101,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	adlistService := adlistsvc.NewService(cluster, auditLogService)
 	authService := authsvc.NewService(userStore, sessionManager, logger)
 	clusterBlockingService := clusterblockingsvc.NewService(cluster, broker, auditLogService, cfg.Publishers.ClusterBlocking, logger)
+	configService := configsvc.NewService(cluster, auditLogService)
 	domainRuleService := domainrulesvc.NewService(cluster, auditLogService)
 	eventsService := eventssvc.NewService(broker, logger)
 	groupService := groupsvc.NewService(cluster, auditLogService)
@@ -156,6 +158,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 		AuditLogService:        auditLogService,
 		AuthService:            authService,
 		ClusterBlockingService: clusterBlockingService,
+		ConfigService:          configService,
 		DomainRuleService:      domainRuleService,
 		GroupService:           groupService,
 		HealthService:          healthService,

--- a/backend/internal/domain/auditlog.go
+++ b/backend/internal/domain/auditlog.go
@@ -19,6 +19,7 @@ const (
 	AuditActionRemoveGroup        AuditAction = "remove_group"
 	AuditActionUpdateClient       AuditAction = "update_client"
 	AuditActionRemoveClient       AuditAction = "remove_client"
+	AuditActionUpdateConfig       AuditAction = "update_config"
 )
 
 type AuditNodeResult struct {

--- a/backend/internal/domain/config.go
+++ b/backend/internal/domain/config.go
@@ -77,15 +77,9 @@ type PiholeConfigResolver struct {
 	NetworkNames bool
 }
 
-// NodeConfigResult is a per-node config read result.
-type NodeConfigResult struct {
-	Config *PiholeConfig
-}
-
 // ClusterConfig aggregates per-node configs with drift detection.
 type ClusterConfig struct {
-	// Consensus holds the value from the first node (or majority); used as the
-	// displayed value when no drift. Nil if all nodes errored.
+	// Consensus holds the config from the lowest-ID node; nil if all nodes errored.
 	Consensus *PiholeConfig
 	// PerNode holds each node's raw config for drift computation on the frontend.
 	PerNode map[int64]*PiholeConfig

--- a/backend/internal/domain/config.go
+++ b/backend/internal/domain/config.go
@@ -1,0 +1,158 @@
+package domain
+
+// PiholeConfig holds the subset of Pi-hole config fields managed by the cluster admin.
+// All fields use pointers so callers can distinguish "not set" from zero value when
+// building partial PATCH requests.
+type PiholeConfig struct {
+	DNS       PiholeConfigDNS
+	Misc      PiholeConfigMisc
+	FTL       PiholeConfigFTL
+	Webserver PiholeConfigWebserver
+	Resolver  PiholeConfigResolver
+}
+
+type PiholeConfigDNS struct {
+	Upstreams    []string
+	Interface    string
+	Port         int
+	DNSSEC       bool
+	DomainNeeded bool
+	ExpandHosts  bool
+	LocalTTL     int
+	BlockingMode string
+	BlockingIPv4 string
+	BlockingIPv6 string
+	RateLimit    PiholeConfigRateLimit
+	RevServer    PiholeConfigRevServer
+	PiholePTR    string
+	QueryLog     PiholeConfigQueryLog
+}
+
+type PiholeConfigRateLimit struct {
+	Count    int
+	Interval int
+}
+
+type PiholeConfigRevServer struct {
+	Active bool
+	CIDR   string
+	Target string
+	Domain string
+}
+
+type PiholeConfigQueryLog struct {
+	Enabled bool
+}
+
+type PiholeConfigMisc struct {
+	PrivacyLevel int
+	DelayStartup int
+	Nice         int
+}
+
+type PiholeConfigFTL struct {
+	QueryDisplay string
+	DelayStartup int
+	Database     PiholeConfigFTLDatabase
+}
+
+type PiholeConfigFTLDatabase struct {
+	DBInterval float64
+	MaxDBDays  int
+}
+
+type PiholeConfigWebserver struct {
+	API PiholeConfigWebserverAPI
+}
+
+type PiholeConfigWebserverAPI struct {
+	ExcludeClients []string
+	ExcludeDomains []string
+	MaxHistory     int
+}
+
+type PiholeConfigResolver struct {
+	ResolveIPv4  bool
+	ResolveIPv6  bool
+	NetworkNames bool
+}
+
+// NodeConfigResult is a per-node config read result.
+type NodeConfigResult struct {
+	Config *PiholeConfig
+}
+
+// ClusterConfig aggregates per-node configs with drift detection.
+type ClusterConfig struct {
+	// Consensus holds the value from the first node (or majority); used as the
+	// displayed value when no drift. Nil if all nodes errored.
+	Consensus *PiholeConfig
+	// PerNode holds each node's raw config for drift computation on the frontend.
+	PerNode map[int64]*PiholeConfig
+	// Drifted is true if any field differs across nodes.
+	Drifted bool
+}
+
+// PiholeConfigPatch is the set of fields the caller wants to change.
+// Each field is a pointer; nil means "leave unchanged."
+type PiholeConfigPatch struct {
+	DNS       *PiholeConfigDNSPatch
+	Misc      *PiholeConfigMiscPatch
+	FTL       *PiholeConfigFTLPatch
+	Webserver *PiholeConfigWebserverPatch
+	Resolver  *PiholeConfigResolverPatch
+}
+
+type PiholeConfigDNSPatch struct {
+	Upstreams    *[]string
+	Interface    *string
+	Port         *int
+	DNSSEC       *bool
+	DomainNeeded *bool
+	ExpandHosts  *bool
+	LocalTTL     *int
+	BlockingMode *string
+	BlockingIPv4 *string
+	BlockingIPv6 *string
+	RateLimit    *PiholeConfigRateLimit
+	RevServer    *PiholeConfigRevServer
+	PiholePTR    *string
+	QueryLog     *PiholeConfigQueryLogPatch
+}
+
+type PiholeConfigQueryLogPatch struct {
+	Enabled *bool
+}
+
+type PiholeConfigMiscPatch struct {
+	PrivacyLevel *int
+	DelayStartup *int
+	Nice         *int
+}
+
+type PiholeConfigFTLPatch struct {
+	QueryDisplay *string
+	DelayStartup *int
+	Database     *PiholeConfigFTLDatabasePatch
+}
+
+type PiholeConfigFTLDatabasePatch struct {
+	DBInterval *float64
+	MaxDBDays  *int
+}
+
+type PiholeConfigWebserverPatch struct {
+	API *PiholeConfigWebserverAPIPatch
+}
+
+type PiholeConfigWebserverAPIPatch struct {
+	ExcludeClients *[]string
+	ExcludeDomains *[]string
+	MaxHistory     *int
+}
+
+type PiholeConfigResolverPatch struct {
+	ResolveIPv4  *bool
+	ResolveIPv6  *bool
+	NetworkNames *bool
+}

--- a/backend/internal/http/api/v1/config_dto.go
+++ b/backend/internal/http/api/v1/config_dto.go
@@ -1,0 +1,328 @@
+package v1
+
+import "github.com/auto-dns/pihole-cluster-admin/internal/domain"
+
+// GET /config response
+
+type getConfigResponseDTO struct {
+	Consensus *configDTO            `json:"consensus"`
+	PerNode   map[int64]*configDTO  `json:"perNode"`
+	Drifted   bool                  `json:"drifted"`
+}
+
+type configDTO struct {
+	DNS       configDNSDTO       `json:"dns"`
+	Misc      configMiscDTO      `json:"misc"`
+	FTL       configFTLDTO       `json:"ftl"`
+	Webserver configWebserverDTO `json:"webserver"`
+	Resolver  configResolverDTO  `json:"resolver"`
+}
+
+type configDNSDTO struct {
+	Upstreams    []string              `json:"upstreams"`
+	Interface    string                `json:"interface"`
+	Port         int                   `json:"port"`
+	DNSSEC       bool                  `json:"dnssec"`
+	DomainNeeded bool                  `json:"domainNeeded"`
+	ExpandHosts  bool                  `json:"expandHosts"`
+	LocalTTL     int                   `json:"localTTL"`
+	BlockingMode string                `json:"blockingmode"`
+	BlockingIPv4 string                `json:"blockingipv4"`
+	BlockingIPv6 string                `json:"blockingipv6"`
+	RateLimit    configRateLimitDTO    `json:"ratelimit"`
+	RevServer    configRevServerDTO    `json:"revServer"`
+	PiholePTR    string                `json:"piholePTR"`
+	QueryLog     configQueryLogDTO     `json:"querylog"`
+}
+
+type configRateLimitDTO struct {
+	Count    int `json:"count"`
+	Interval int `json:"interval"`
+}
+
+type configRevServerDTO struct {
+	Active bool   `json:"active"`
+	CIDR   string `json:"cidr"`
+	Target string `json:"target"`
+	Domain string `json:"domain"`
+}
+
+type configQueryLogDTO struct {
+	Enabled bool `json:"enabled"`
+}
+
+type configMiscDTO struct {
+	PrivacyLevel int `json:"privacylevel"`
+	DelayStartup int `json:"delay_startup"`
+	Nice         int `json:"nice"`
+}
+
+type configFTLDTO struct {
+	QueryDisplay string          `json:"query_display"`
+	DelayStartup int             `json:"delay_startup"`
+	Database     configFTLDBDTO  `json:"database"`
+}
+
+type configFTLDBDTO struct {
+	DBInterval float64 `json:"DBinterval"`
+	MaxDBDays  int     `json:"maxDBdays"`
+}
+
+type configWebserverDTO struct {
+	API configWebserverAPIDTO `json:"api"`
+}
+
+type configWebserverAPIDTO struct {
+	ExcludeClients []string `json:"excludeClients"`
+	ExcludeDomains []string `json:"excludeDomains"`
+	MaxHistory     int      `json:"maxHistory"`
+}
+
+type configResolverDTO struct {
+	ResolveIPv4  bool `json:"resolveIPv4"`
+	ResolveIPv6  bool `json:"resolveIPv6"`
+	NetworkNames bool `json:"networkNames"`
+}
+
+// PATCH /config request
+
+type patchConfigRequestDTO struct {
+	DNS       *patchConfigDNSDTO       `json:"dns,omitempty"`
+	Misc      *patchConfigMiscDTO      `json:"misc,omitempty"`
+	FTL       *patchConfigFTLDTO       `json:"ftl,omitempty"`
+	Webserver *patchConfigWebserverDTO `json:"webserver,omitempty"`
+	Resolver  *patchConfigResolverDTO  `json:"resolver,omitempty"`
+}
+
+type patchConfigDNSDTO struct {
+	Upstreams    *[]string                  `json:"upstreams,omitempty"`
+	Interface    *string                    `json:"interface,omitempty"`
+	Port         *int                       `json:"port,omitempty"`
+	DNSSEC       *bool                      `json:"dnssec,omitempty"`
+	DomainNeeded *bool                      `json:"domainNeeded,omitempty"`
+	ExpandHosts  *bool                      `json:"expandHosts,omitempty"`
+	LocalTTL     *int                       `json:"localTTL,omitempty"`
+	BlockingMode *string                    `json:"blockingmode,omitempty"`
+	BlockingIPv4 *string                    `json:"blockingipv4,omitempty"`
+	BlockingIPv6 *string                    `json:"blockingipv6,omitempty"`
+	RateLimit    *patchConfigRateLimitDTO   `json:"ratelimit,omitempty"`
+	RevServer    *patchConfigRevServerDTO   `json:"revServer,omitempty"`
+	PiholePTR    *string                    `json:"piholePTR,omitempty"`
+	QueryLog     *patchConfigQueryLogDTO    `json:"querylog,omitempty"`
+}
+
+type patchConfigRateLimitDTO struct {
+	Count    *int `json:"count,omitempty"`
+	Interval *int `json:"interval,omitempty"`
+}
+
+type patchConfigRevServerDTO struct {
+	Active *bool   `json:"active,omitempty"`
+	CIDR   *string `json:"cidr,omitempty"`
+	Target *string `json:"target,omitempty"`
+	Domain *string `json:"domain,omitempty"`
+}
+
+type patchConfigQueryLogDTO struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type patchConfigMiscDTO struct {
+	PrivacyLevel *int `json:"privacylevel,omitempty"`
+	DelayStartup *int `json:"delay_startup,omitempty"`
+	Nice         *int `json:"nice,omitempty"`
+}
+
+type patchConfigFTLDTO struct {
+	QueryDisplay *string              `json:"query_display,omitempty"`
+	DelayStartup *int                 `json:"delay_startup,omitempty"`
+	Database     *patchConfigFTLDBDTO `json:"database,omitempty"`
+}
+
+type patchConfigFTLDBDTO struct {
+	DBInterval *float64 `json:"DBinterval,omitempty"`
+	MaxDBDays  *int     `json:"maxDBdays,omitempty"`
+}
+
+type patchConfigWebserverDTO struct {
+	API *patchConfigWebserverAPIDTO `json:"api,omitempty"`
+}
+
+type patchConfigWebserverAPIDTO struct {
+	ExcludeClients *[]string `json:"excludeClients,omitempty"`
+	ExcludeDomains *[]string `json:"excludeDomains,omitempty"`
+	MaxHistory     *int      `json:"maxHistory,omitempty"`
+}
+
+type patchConfigResolverDTO struct {
+	ResolveIPv4  *bool `json:"resolveIPv4,omitempty"`
+	ResolveIPv6  *bool `json:"resolveIPv6,omitempty"`
+	NetworkNames *bool `json:"networkNames,omitempty"`
+}
+
+// PATCH /config response
+
+type patchConfigResponseDTO struct {
+	Nodes map[int64]patchConfigNodeDTO `json:"nodes"`
+}
+
+type patchConfigNodeDTO struct {
+	Node    piholeNodeRefDTO `json:"node"`
+	Success bool             `json:"success"`
+	Error   string           `json:"error,omitempty"`
+}
+
+// Converters
+
+func toConfigDTO(c domain.PiholeConfig) configDTO {
+	ups := c.DNS.Upstreams
+	if ups == nil {
+		ups = []string{}
+	}
+	excClients := c.Webserver.API.ExcludeClients
+	if excClients == nil {
+		excClients = []string{}
+	}
+	excDomains := c.Webserver.API.ExcludeDomains
+	if excDomains == nil {
+		excDomains = []string{}
+	}
+	return configDTO{
+		DNS: configDNSDTO{
+			Upstreams:    ups,
+			Interface:    c.DNS.Interface,
+			Port:         c.DNS.Port,
+			DNSSEC:       c.DNS.DNSSEC,
+			DomainNeeded: c.DNS.DomainNeeded,
+			ExpandHosts:  c.DNS.ExpandHosts,
+			LocalTTL:     c.DNS.LocalTTL,
+			BlockingMode: c.DNS.BlockingMode,
+			BlockingIPv4: c.DNS.BlockingIPv4,
+			BlockingIPv6: c.DNS.BlockingIPv6,
+			RateLimit: configRateLimitDTO{
+				Count:    c.DNS.RateLimit.Count,
+				Interval: c.DNS.RateLimit.Interval,
+			},
+			RevServer: configRevServerDTO{
+				Active: c.DNS.RevServer.Active,
+				CIDR:   c.DNS.RevServer.CIDR,
+				Target: c.DNS.RevServer.Target,
+				Domain: c.DNS.RevServer.Domain,
+			},
+			PiholePTR: c.DNS.PiholePTR,
+			QueryLog:  configQueryLogDTO{Enabled: c.DNS.QueryLog.Enabled},
+		},
+		Misc: configMiscDTO{
+			PrivacyLevel: c.Misc.PrivacyLevel,
+			DelayStartup: c.Misc.DelayStartup,
+			Nice:         c.Misc.Nice,
+		},
+		FTL: configFTLDTO{
+			QueryDisplay: c.FTL.QueryDisplay,
+			DelayStartup: c.FTL.DelayStartup,
+			Database: configFTLDBDTO{
+				DBInterval: c.FTL.Database.DBInterval,
+				MaxDBDays:  c.FTL.Database.MaxDBDays,
+			},
+		},
+		Webserver: configWebserverDTO{
+			API: configWebserverAPIDTO{
+				ExcludeClients: excClients,
+				ExcludeDomains: excDomains,
+				MaxHistory:     c.Webserver.API.MaxHistory,
+			},
+		},
+		Resolver: configResolverDTO{
+			ResolveIPv4:  c.Resolver.ResolveIPv4,
+			ResolveIPv6:  c.Resolver.ResolveIPv6,
+			NetworkNames: c.Resolver.NetworkNames,
+		},
+	}
+}
+
+func patchRequestToDomain(req patchConfigRequestDTO) domain.PiholeConfigPatch {
+	patch := domain.PiholeConfigPatch{}
+	if req.DNS != nil {
+		d := req.DNS
+		dp := &domain.PiholeConfigDNSPatch{
+			Upstreams:    d.Upstreams,
+			Interface:    d.Interface,
+			Port:         d.Port,
+			DNSSEC:       d.DNSSEC,
+			DomainNeeded: d.DomainNeeded,
+			ExpandHosts:  d.ExpandHosts,
+			LocalTTL:     d.LocalTTL,
+			BlockingMode: d.BlockingMode,
+			BlockingIPv4: d.BlockingIPv4,
+			BlockingIPv6: d.BlockingIPv6,
+			PiholePTR:    d.PiholePTR,
+		}
+		if d.RateLimit != nil {
+			rl := domain.PiholeConfigRateLimit{}
+			if d.RateLimit.Count != nil {
+				rl.Count = *d.RateLimit.Count
+			}
+			if d.RateLimit.Interval != nil {
+				rl.Interval = *d.RateLimit.Interval
+			}
+			dp.RateLimit = &rl
+		}
+		if d.RevServer != nil {
+			rs := domain.PiholeConfigRevServer{}
+			if d.RevServer.Active != nil {
+				rs.Active = *d.RevServer.Active
+			}
+			if d.RevServer.CIDR != nil {
+				rs.CIDR = *d.RevServer.CIDR
+			}
+			if d.RevServer.Target != nil {
+				rs.Target = *d.RevServer.Target
+			}
+			if d.RevServer.Domain != nil {
+				rs.Domain = *d.RevServer.Domain
+			}
+			dp.RevServer = &rs
+		}
+		if d.QueryLog != nil {
+			dp.QueryLog = &domain.PiholeConfigQueryLogPatch{Enabled: d.QueryLog.Enabled}
+		}
+		patch.DNS = dp
+	}
+	if req.Misc != nil {
+		patch.Misc = &domain.PiholeConfigMiscPatch{
+			PrivacyLevel: req.Misc.PrivacyLevel,
+			DelayStartup: req.Misc.DelayStartup,
+			Nice:         req.Misc.Nice,
+		}
+	}
+	if req.FTL != nil {
+		fp := &domain.PiholeConfigFTLPatch{
+			QueryDisplay: req.FTL.QueryDisplay,
+			DelayStartup: req.FTL.DelayStartup,
+		}
+		if req.FTL.Database != nil {
+			fp.Database = &domain.PiholeConfigFTLDatabasePatch{
+				DBInterval: req.FTL.Database.DBInterval,
+				MaxDBDays:  req.FTL.Database.MaxDBDays,
+			}
+		}
+		patch.FTL = fp
+	}
+	if req.Webserver != nil && req.Webserver.API != nil {
+		patch.Webserver = &domain.PiholeConfigWebserverPatch{
+			API: &domain.PiholeConfigWebserverAPIPatch{
+				ExcludeClients: req.Webserver.API.ExcludeClients,
+				ExcludeDomains: req.Webserver.API.ExcludeDomains,
+				MaxHistory:     req.Webserver.API.MaxHistory,
+			},
+		}
+	}
+	if req.Resolver != nil {
+		patch.Resolver = &domain.PiholeConfigResolverPatch{
+			ResolveIPv4:  req.Resolver.ResolveIPv4,
+			ResolveIPv6:  req.Resolver.ResolveIPv6,
+			NetworkNames: req.Resolver.NetworkNames,
+		}
+	}
+	return patch
+}

--- a/backend/internal/http/api/v1/config_handlers.go
+++ b/backend/internal/http/api/v1/config_handlers.go
@@ -54,6 +54,7 @@ func configPatch(d Deps) http.HandlerFunc {
 		dto := patchConfigResponseDTO{
 			Nodes: make(map[int64]patchConfigNodeDTO, len(results)),
 		}
+		successCount := 0
 		for id, nr := range results {
 			node := patchConfigNodeDTO{
 				Node: piholeNodeRefDTO{
@@ -66,9 +67,16 @@ func configPatch(d Deps) http.HandlerFunc {
 			if nr.Error != nil {
 				node.Error = nr.Error.Error()
 			}
+			if nr.Success {
+				successCount++
+			}
 			dto.Nodes[id] = node
 		}
 
-		transport.WriteJSON(w, http.StatusOK, dto)
+		status := http.StatusOK
+		if successCount < len(results) {
+			status = http.StatusMultiStatus
+		}
+		transport.WriteJSON(w, status, dto)
 	}
 }

--- a/backend/internal/http/api/v1/config_handlers.go
+++ b/backend/internal/http/api/v1/config_handlers.go
@@ -1,0 +1,74 @@
+package v1
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/http/transport"
+	"github.com/go-chi/chi"
+)
+
+func registerConfig(r chi.Router, d Deps) {
+	r.Route("/config", func(r chi.Router) {
+		r.Get("/", configGet(d))
+		r.Patch("/", configPatch(d))
+	})
+}
+
+func configGet(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		result := d.ConfigService.GetClusterConfig(r.Context())
+
+		dto := getConfigResponseDTO{
+			Drifted: result.Drifted,
+			PerNode: make(map[int64]*configDTO, len(result.PerNode)),
+		}
+		if result.Consensus != nil {
+			c := toConfigDTO(*result.Consensus)
+			dto.Consensus = &c
+		}
+		for id, cfg := range result.PerNode {
+			c := toConfigDTO(*cfg)
+			dto.PerNode[id] = &c
+		}
+
+		transport.WriteJSON(w, http.StatusOK, dto)
+	}
+}
+
+func configPatch(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body patchConfigRequestDTO
+		if err := transport.DecodeJSONBody(w, r, &body, 1<<20); err != nil {
+			transport.WriteErr(w, err)
+			return
+		}
+		if body.DNS == nil && body.Misc == nil && body.FTL == nil && body.Webserver == nil && body.Resolver == nil {
+			transport.WriteBadRequestErr(w, "no fields to update", errors.New("no fields to update"))
+			return
+		}
+
+		patch := patchRequestToDomain(body)
+		results := d.ConfigService.PatchConfig(r.Context(), patch)
+
+		dto := patchConfigResponseDTO{
+			Nodes: make(map[int64]patchConfigNodeDTO, len(results)),
+		}
+		for id, nr := range results {
+			node := patchConfigNodeDTO{
+				Node: piholeNodeRefDTO{
+					Id:   nr.PiholeNode.Id,
+					Name: nr.PiholeNode.Name,
+					Host: nr.PiholeNode.Host,
+				},
+				Success: nr.Success,
+			}
+			if nr.Error != nil {
+				node.Error = nr.Error.Error()
+			}
+			dto.Nodes[id] = node
+		}
+
+		transport.WriteJSON(w, http.StatusOK, dto)
+	}
+}

--- a/backend/internal/http/api/v1/interface.go
+++ b/backend/internal/http/api/v1/interface.go
@@ -91,6 +91,11 @@ type setupService interface {
 	UpdatePiholeInitializationStatus(params setupsvc.UpdatePiholeInitializationStatusCommand) error
 }
 
+type configService interface {
+	GetClusterConfig(ctx context.Context) domain.ClusterConfig
+	PatchConfig(ctx context.Context, patch domain.PiholeConfigPatch) map[int64]*domain.NodeResult[struct{}]
+}
+
 type syncService interface {
 	SyncFromNode(ctx context.Context, sourceNodeId int64) ([]domain.SyncNodeResult, error)
 }

--- a/backend/internal/http/api/v1/router.go
+++ b/backend/internal/http/api/v1/router.go
@@ -13,6 +13,7 @@ type Deps struct {
 	AuditLogService        auditLogService
 	AuthService            authService
 	ClusterBlockingService clusterBlockingService
+	ConfigService          configService
 	DomainRuleService      domainRuleService
 	GroupService           groupService
 	HealthService          healthService
@@ -49,6 +50,7 @@ func RegisterAPIV1(r chi.Router, d Deps) {
 		registerAuditLog(r, d)
 		registerAuthPrivate(r, d)
 		registerClusterBlocking(r, d)
+		registerConfig(r, d)
 		registerPiholeClients(r, d)
 		registerDiagnose(r, d)
 		registerGroups(r, d)

--- a/backend/internal/pihole/client.go
+++ b/backend/internal/pihole/client.go
@@ -1238,10 +1238,11 @@ func (c *Client) PatchConfig(ctx context.Context, patch domain.PiholeConfigPatch
 		return fmt.Errorf("patching config: %w", err)
 	}
 	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return &httpStatusError{Status: resp.StatusCode}
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return &httpStatusError{Status: resp.StatusCode, Body: string(b)}
 	}
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
 }
 

--- a/backend/internal/pihole/client.go
+++ b/backend/internal/pihole/client.go
@@ -1197,6 +1197,54 @@ func (c *Client) SetPassword(ctx context.Context, newPassword string) error {
 	return nil
 }
 
+func (c *Client) GetConfig(ctx context.Context) (*domain.PiholeConfig, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.getBaseURL()+"/config", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("getting config: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, &httpStatusError{Status: resp.StatusCode, Body: string(b)}
+	}
+	var wire piholeConfigWireResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wire); err != nil {
+		return nil, fmt.Errorf("decoding config: %w", err)
+	}
+	cfg := configFromWire(wire.Config)
+	return &cfg, nil
+}
+
+func (c *Client) PatchConfig(ctx context.Context, patch domain.PiholeConfigPatch) error {
+	wire := patchToWire(patch)
+	body, err := json.Marshal(wire)
+	if err != nil {
+		return fmt.Errorf("marshaling patch: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.getBaseURL()+"/config", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return fmt.Errorf("patching config: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return &httpStatusError{Status: resp.StatusCode}
+	}
+	return nil
+}
+
 // Groups
 
 func toGroup(w groupWireEntry) domain.Group {

--- a/backend/internal/pihole/cluster.go
+++ b/backend/internal/pihole/cluster.go
@@ -511,6 +511,20 @@ func (c *Cluster) TestRegex(ctx context.Context, testDomain string) map[int64]*d
 	return out
 }
 
+func (c *Cluster) GetConfig(ctx context.Context) map[int64]*domain.NodeResult[*domain.PiholeConfig] {
+	out, _ := fanout(c, ctx, 0, 5*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (*domain.PiholeConfig, error) {
+		return client.GetConfig(nodeCtx)
+	})
+	return out
+}
+
+func (c *Cluster) PatchConfig(ctx context.Context, patch domain.PiholeConfigPatch) map[int64]*domain.NodeResult[struct{}] {
+	out, _ := fanout(c, ctx, 0, 5*time.Second, func(nodeCtx context.Context, _ int64, client clientPort) (struct{}, error) {
+		return struct{}{}, client.PatchConfig(nodeCtx, patch)
+	})
+	return out
+}
+
 func (c *Cluster) SetPasswordForNode(ctx context.Context, nodeID int64, newPassword string) error {
 	c.rw.RLock()
 	client, exists := c.clients[nodeID]

--- a/backend/internal/pihole/interface.go
+++ b/backend/internal/pihole/interface.go
@@ -45,6 +45,8 @@ type clientPort interface {
 	RemovePiholeClient(ctx context.Context, cmd domain.RemovePiholeClientCommand) error
 	SetPassword(ctx context.Context, newPassword string) error
 	TestRegex(ctx context.Context, testDomain string) (*domain.RegexTestResult, error)
+	GetConfig(ctx context.Context) (*domain.PiholeConfig, error)
+	PatchConfig(ctx context.Context, patch domain.PiholeConfigPatch) error
 }
 
 type cursorManagerPort[T any] interface {

--- a/backend/internal/pihole/wire.go
+++ b/backend/internal/pihole/wire.go
@@ -406,7 +406,7 @@ type piholeConfigPatchWire struct {
 }
 
 type piholeConfigDNSPatchWire struct {
-	Upstreams    []string                          `json:"upstreams,omitempty"`
+	Upstreams    *[]string                         `json:"upstreams,omitempty"`
 	Interface    *string                           `json:"interface,omitempty"`
 	Port         *int                              `json:"port,omitempty"`
 	DNSSEC       *bool                             `json:"dnssec,omitempty"`
@@ -460,9 +460,9 @@ type piholeConfigWebserverPatchWire struct {
 }
 
 type piholeConfigWebserverAPIPatchWire struct {
-	ExcludeClients []string `json:"excludeClients,omitempty"`
-	ExcludeDomains []string `json:"excludeDomains,omitempty"`
-	MaxHistory     *int     `json:"maxHistory,omitempty"`
+	ExcludeClients *[]string `json:"excludeClients,omitempty"`
+	ExcludeDomains *[]string `json:"excludeDomains,omitempty"`
+	MaxHistory     *int      `json:"maxHistory,omitempty"`
 }
 
 type piholeConfigResolverPatchWire struct {
@@ -531,7 +531,7 @@ func patchToWire(p domain.PiholeConfigPatch) piholeConfigPatchWire {
 	if p.DNS != nil {
 		d := p.DNS
 		dw := &piholeConfigDNSPatchWire{
-			Upstreams:    fromPtrSlice(d.Upstreams),
+			Upstreams:    d.Upstreams,
 			Interface:    d.Interface,
 			Port:         d.Port,
 			DNSSEC:       d.DNSSEC,
@@ -586,8 +586,8 @@ func patchToWire(p domain.PiholeConfigPatch) piholeConfigPatchWire {
 		aw := p.Webserver.API
 		out.Webserver = &piholeConfigWebserverPatchWire{
 			API: &piholeConfigWebserverAPIPatchWire{
-				ExcludeClients: fromPtrSlice(aw.ExcludeClients),
-				ExcludeDomains: fromPtrSlice(aw.ExcludeDomains),
+				ExcludeClients: aw.ExcludeClients,
+				ExcludeDomains: aw.ExcludeDomains,
 				MaxHistory:     aw.MaxHistory,
 			},
 		}
@@ -600,11 +600,4 @@ func patchToWire(p domain.PiholeConfigPatch) piholeConfigPatchWire {
 		}
 	}
 	return out
-}
-
-func fromPtrSlice[T any](p *[]T) []T {
-	if p == nil {
-		return nil
-	}
-	return *p
 }

--- a/backend/internal/pihole/wire.go
+++ b/backend/internal/pihole/wire.go
@@ -324,3 +324,287 @@ type addDomainsWireResponse struct {
 type regexTestWireRequest struct {
 	Domain string `json:"domain"`
 }
+
+// Config
+
+type piholeConfigWireResponse struct {
+	Config piholeConfigWire `json:"config"`
+}
+
+type piholeConfigWire struct {
+	DNS       piholeConfigDNSWire       `json:"dns"`
+	Misc      piholeConfigMiscWire      `json:"misc"`
+	FTL       piholeConfigFTLWire       `json:"ftl"`
+	Webserver piholeConfigWebserverWire `json:"webserver"`
+	Resolver  piholeConfigResolverWire  `json:"resolver"`
+}
+
+type piholeConfigDNSWire struct {
+	Upstreams    []string `json:"upstreams"`
+	Interface    string   `json:"interface"`
+	Port         int      `json:"port"`
+	DNSSEC       bool     `json:"dnssec"`
+	DomainNeeded bool     `json:"domainNeeded"`
+	ExpandHosts  bool     `json:"expandHosts"`
+	LocalTTL     int      `json:"localTTL"`
+	BlockingMode string   `json:"blockingmode"`
+	BlockingIPv4 string   `json:"blockingipv4"`
+	BlockingIPv6 string   `json:"blockingipv6"`
+	RateLimit    struct {
+		Count    int `json:"count"`
+		Interval int `json:"interval"`
+	} `json:"ratelimit"`
+	RevServer struct {
+		Active bool   `json:"active"`
+		CIDR   string `json:"cidr"`
+		Target string `json:"target"`
+		Domain string `json:"domain"`
+	} `json:"revServer"`
+	PiholePTR string `json:"piholePTR"`
+	QueryLog  struct {
+		Enabled bool `json:"enabled"`
+	} `json:"querylog"`
+}
+
+type piholeConfigMiscWire struct {
+	PrivacyLevel int `json:"privacylevel"`
+	DelayStartup int `json:"delay_startup"`
+	Nice         int `json:"nice"`
+}
+
+type piholeConfigFTLWire struct {
+	QueryDisplay string `json:"query_display"`
+	DelayStartup int    `json:"delay_startup"`
+	Database     struct {
+		DBInterval float64 `json:"DBinterval"`
+		MaxDBDays  int     `json:"maxDBdays"`
+	} `json:"database"`
+}
+
+type piholeConfigWebserverWire struct {
+	API struct {
+		ExcludeClients []string `json:"excludeClients"`
+		ExcludeDomains []string `json:"excludeDomains"`
+		MaxHistory     int      `json:"maxHistory"`
+	} `json:"api"`
+}
+
+type piholeConfigResolverWire struct {
+	ResolveIPv4  bool `json:"resolveIPv4"`
+	ResolveIPv6  bool `json:"resolveIPv6"`
+	NetworkNames bool `json:"networkNames"`
+}
+
+// piholeConfigPatchWire mirrors the nested config tree but with all fields
+// omitempty so only explicitly set fields are sent to Pi-hole.
+type piholeConfigPatchWire struct {
+	DNS       *piholeConfigDNSPatchWire       `json:"dns,omitempty"`
+	Misc      *piholeConfigMiscPatchWire      `json:"misc,omitempty"`
+	FTL       *piholeConfigFTLPatchWire       `json:"ftl,omitempty"`
+	Webserver *piholeConfigWebserverPatchWire `json:"webserver,omitempty"`
+	Resolver  *piholeConfigResolverPatchWire  `json:"resolver,omitempty"`
+}
+
+type piholeConfigDNSPatchWire struct {
+	Upstreams    []string                          `json:"upstreams,omitempty"`
+	Interface    *string                           `json:"interface,omitempty"`
+	Port         *int                              `json:"port,omitempty"`
+	DNSSEC       *bool                             `json:"dnssec,omitempty"`
+	DomainNeeded *bool                             `json:"domainNeeded,omitempty"`
+	ExpandHosts  *bool                             `json:"expandHosts,omitempty"`
+	LocalTTL     *int                              `json:"localTTL,omitempty"`
+	BlockingMode *string                           `json:"blockingmode,omitempty"`
+	BlockingIPv4 *string                           `json:"blockingipv4,omitempty"`
+	BlockingIPv6 *string                           `json:"blockingipv6,omitempty"`
+	RateLimit    *piholeConfigRateLimitPatchWire   `json:"ratelimit,omitempty"`
+	RevServer    *piholeConfigRevServerPatchWire   `json:"revServer,omitempty"`
+	PiholePTR    *string                           `json:"piholePTR,omitempty"`
+	QueryLog     *piholeConfigQueryLogPatchWire    `json:"querylog,omitempty"`
+}
+
+type piholeConfigRateLimitPatchWire struct {
+	Count    *int `json:"count,omitempty"`
+	Interval *int `json:"interval,omitempty"`
+}
+
+type piholeConfigRevServerPatchWire struct {
+	Active *bool   `json:"active,omitempty"`
+	CIDR   *string `json:"cidr,omitempty"`
+	Target *string `json:"target,omitempty"`
+	Domain *string `json:"domain,omitempty"`
+}
+
+type piholeConfigQueryLogPatchWire struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type piholeConfigMiscPatchWire struct {
+	PrivacyLevel *int `json:"privacylevel,omitempty"`
+	DelayStartup *int `json:"delay_startup,omitempty"`
+	Nice         *int `json:"nice,omitempty"`
+}
+
+type piholeConfigFTLPatchWire struct {
+	QueryDisplay *string                        `json:"query_display,omitempty"`
+	DelayStartup *int                           `json:"delay_startup,omitempty"`
+	Database     *piholeConfigFTLDBPatchWire    `json:"database,omitempty"`
+}
+
+type piholeConfigFTLDBPatchWire struct {
+	DBInterval *float64 `json:"DBinterval,omitempty"`
+	MaxDBDays  *int     `json:"maxDBdays,omitempty"`
+}
+
+type piholeConfigWebserverPatchWire struct {
+	API *piholeConfigWebserverAPIPatchWire `json:"api,omitempty"`
+}
+
+type piholeConfigWebserverAPIPatchWire struct {
+	ExcludeClients []string `json:"excludeClients,omitempty"`
+	ExcludeDomains []string `json:"excludeDomains,omitempty"`
+	MaxHistory     *int     `json:"maxHistory,omitempty"`
+}
+
+type piholeConfigResolverPatchWire struct {
+	ResolveIPv4  *bool `json:"resolveIPv4,omitempty"`
+	ResolveIPv6  *bool `json:"resolveIPv6,omitempty"`
+	NetworkNames *bool `json:"networkNames,omitempty"`
+}
+
+func configFromWire(w piholeConfigWire) domain.PiholeConfig {
+	cfg := domain.PiholeConfig{}
+	d := w.DNS
+	cfg.DNS = domain.PiholeConfigDNS{
+		Upstreams:    d.Upstreams,
+		Interface:    d.Interface,
+		Port:         d.Port,
+		DNSSEC:       d.DNSSEC,
+		DomainNeeded: d.DomainNeeded,
+		ExpandHosts:  d.ExpandHosts,
+		LocalTTL:     d.LocalTTL,
+		BlockingMode: d.BlockingMode,
+		BlockingIPv4: d.BlockingIPv4,
+		BlockingIPv6: d.BlockingIPv6,
+		RateLimit: domain.PiholeConfigRateLimit{
+			Count:    d.RateLimit.Count,
+			Interval: d.RateLimit.Interval,
+		},
+		RevServer: domain.PiholeConfigRevServer{
+			Active: d.RevServer.Active,
+			CIDR:   d.RevServer.CIDR,
+			Target: d.RevServer.Target,
+			Domain: d.RevServer.Domain,
+		},
+		PiholePTR: d.PiholePTR,
+		QueryLog:  domain.PiholeConfigQueryLog{Enabled: d.QueryLog.Enabled},
+	}
+	cfg.Misc = domain.PiholeConfigMisc{
+		PrivacyLevel: w.Misc.PrivacyLevel,
+		DelayStartup: w.Misc.DelayStartup,
+		Nice:         w.Misc.Nice,
+	}
+	cfg.FTL = domain.PiholeConfigFTL{
+		QueryDisplay: w.FTL.QueryDisplay,
+		DelayStartup: w.FTL.DelayStartup,
+		Database: domain.PiholeConfigFTLDatabase{
+			DBInterval: w.FTL.Database.DBInterval,
+			MaxDBDays:  w.FTL.Database.MaxDBDays,
+		},
+	}
+	cfg.Webserver = domain.PiholeConfigWebserver{
+		API: domain.PiholeConfigWebserverAPI{
+			ExcludeClients: w.Webserver.API.ExcludeClients,
+			ExcludeDomains: w.Webserver.API.ExcludeDomains,
+			MaxHistory:     w.Webserver.API.MaxHistory,
+		},
+	}
+	cfg.Resolver = domain.PiholeConfigResolver{
+		ResolveIPv4:  w.Resolver.ResolveIPv4,
+		ResolveIPv6:  w.Resolver.ResolveIPv6,
+		NetworkNames: w.Resolver.NetworkNames,
+	}
+	return cfg
+}
+
+func patchToWire(p domain.PiholeConfigPatch) piholeConfigPatchWire {
+	out := piholeConfigPatchWire{}
+	if p.DNS != nil {
+		d := p.DNS
+		dw := &piholeConfigDNSPatchWire{
+			Upstreams:    fromPtrSlice(d.Upstreams),
+			Interface:    d.Interface,
+			Port:         d.Port,
+			DNSSEC:       d.DNSSEC,
+			DomainNeeded: d.DomainNeeded,
+			ExpandHosts:  d.ExpandHosts,
+			LocalTTL:     d.LocalTTL,
+			BlockingMode: d.BlockingMode,
+			BlockingIPv4: d.BlockingIPv4,
+			BlockingIPv6: d.BlockingIPv6,
+			PiholePTR:    d.PiholePTR,
+		}
+		if d.RateLimit != nil {
+			dw.RateLimit = &piholeConfigRateLimitPatchWire{
+				Count:    &d.RateLimit.Count,
+				Interval: &d.RateLimit.Interval,
+			}
+		}
+		if d.RevServer != nil {
+			dw.RevServer = &piholeConfigRevServerPatchWire{
+				Active: &d.RevServer.Active,
+				CIDR:   &d.RevServer.CIDR,
+				Target: &d.RevServer.Target,
+				Domain: &d.RevServer.Domain,
+			}
+		}
+		if d.QueryLog != nil {
+			dw.QueryLog = &piholeConfigQueryLogPatchWire{Enabled: d.QueryLog.Enabled}
+		}
+		out.DNS = dw
+	}
+	if p.Misc != nil {
+		out.Misc = &piholeConfigMiscPatchWire{
+			PrivacyLevel: p.Misc.PrivacyLevel,
+			DelayStartup: p.Misc.DelayStartup,
+			Nice:         p.Misc.Nice,
+		}
+	}
+	if p.FTL != nil {
+		fw := &piholeConfigFTLPatchWire{
+			QueryDisplay: p.FTL.QueryDisplay,
+			DelayStartup: p.FTL.DelayStartup,
+		}
+		if p.FTL.Database != nil {
+			fw.Database = &piholeConfigFTLDBPatchWire{
+				DBInterval: p.FTL.Database.DBInterval,
+				MaxDBDays:  p.FTL.Database.MaxDBDays,
+			}
+		}
+		out.FTL = fw
+	}
+	if p.Webserver != nil && p.Webserver.API != nil {
+		aw := p.Webserver.API
+		out.Webserver = &piholeConfigWebserverPatchWire{
+			API: &piholeConfigWebserverAPIPatchWire{
+				ExcludeClients: fromPtrSlice(aw.ExcludeClients),
+				ExcludeDomains: fromPtrSlice(aw.ExcludeDomains),
+				MaxHistory:     aw.MaxHistory,
+			},
+		}
+	}
+	if p.Resolver != nil {
+		out.Resolver = &piholeConfigResolverPatchWire{
+			ResolveIPv4:  p.Resolver.ResolveIPv4,
+			ResolveIPv6:  p.Resolver.ResolveIPv6,
+			NetworkNames: p.Resolver.NetworkNames,
+		}
+	}
+	return out
+}
+
+func fromPtrSlice[T any](p *[]T) []T {
+	if p == nil {
+		return nil
+	}
+	return *p
+}

--- a/backend/internal/service/configsvc/interface.go
+++ b/backend/internal/service/configsvc/interface.go
@@ -1,0 +1,16 @@
+package configsvc
+
+import (
+	"context"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+)
+
+type cluster interface {
+	GetConfig(ctx context.Context) map[int64]*domain.NodeResult[*domain.PiholeConfig]
+	PatchConfig(ctx context.Context, patch domain.PiholeConfigPatch) map[int64]*domain.NodeResult[struct{}]
+}
+
+type auditLogger interface {
+	Record(ctx context.Context, params domain.CreateAuditEntryParams)
+}

--- a/backend/internal/service/configsvc/service.go
+++ b/backend/internal/service/configsvc/service.go
@@ -3,6 +3,7 @@ package configsvc
 import (
 	"context"
 	"reflect"
+	"sort"
 
 	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
 	"github.com/auto-dns/pihole-cluster-admin/internal/util"
@@ -24,17 +25,27 @@ func (s *Service) GetClusterConfig(ctx context.Context) domain.ClusterConfig {
 		PerNode: make(map[int64]*domain.PiholeConfig, len(results)),
 	}
 
-	var first *domain.PiholeConfig
+	// Populate PerNode for all successful results.
 	for id, nr := range results {
 		if nr.Success && nr.Response != nil {
-			cfg := nr.Response
-			out.PerNode[id] = cfg
-			if first == nil {
-				first = cfg
-				out.Consensus = cfg
-			} else if !reflect.DeepEqual(*first, *cfg) {
-				out.Drifted = true
-			}
+			out.PerNode[id] = nr.Response
+		}
+	}
+
+	// Determine consensus using the lowest node ID so the result is stable
+	// across calls (map iteration order is non-deterministic).
+	ids := make([]int64, 0, len(out.PerNode))
+	for id := range out.PerNode {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	for _, id := range ids {
+		cfg := out.PerNode[id]
+		if out.Consensus == nil {
+			out.Consensus = cfg
+		} else if !reflect.DeepEqual(*out.Consensus, *cfg) {
+			out.Drifted = true
 		}
 	}
 	return out

--- a/backend/internal/service/configsvc/service.go
+++ b/backend/internal/service/configsvc/service.go
@@ -1,0 +1,61 @@
+package configsvc
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/auto-dns/pihole-cluster-admin/internal/domain"
+	"github.com/auto-dns/pihole-cluster-admin/internal/util"
+)
+
+type Service struct {
+	cluster cluster
+	audit   auditLogger
+}
+
+func NewService(cluster cluster, audit auditLogger) *Service {
+	return &Service{cluster: cluster, audit: audit}
+}
+
+func (s *Service) GetClusterConfig(ctx context.Context) domain.ClusterConfig {
+	results := s.cluster.GetConfig(ctx)
+
+	out := domain.ClusterConfig{
+		PerNode: make(map[int64]*domain.PiholeConfig, len(results)),
+	}
+
+	var first *domain.PiholeConfig
+	for id, nr := range results {
+		if nr.Success && nr.Response != nil {
+			cfg := nr.Response
+			out.PerNode[id] = cfg
+			if first == nil {
+				first = cfg
+				out.Consensus = cfg
+			} else if !reflect.DeepEqual(*first, *cfg) {
+				out.Drifted = true
+			}
+		}
+	}
+	return out
+}
+
+func (s *Service) PatchConfig(ctx context.Context, patch domain.PiholeConfigPatch) map[int64]*domain.NodeResult[struct{}] {
+	results := s.cluster.PatchConfig(ctx, patch)
+
+	nodeResults := make([]domain.AuditNodeResult, 0, len(results))
+	for _, nr := range results {
+		nodeResults = append(nodeResults, domain.AuditNodeResult{
+			NodeId:   nr.PiholeNode.Id,
+			NodeName: nr.PiholeNode.Name,
+			Success:  nr.Success,
+			Error:    util.ErrorString(nr.Error),
+		})
+	}
+	s.audit.Record(ctx, domain.CreateAuditEntryParams{
+		Action:      domain.AuditActionUpdateConfig,
+		NodeResults: nodeResults,
+	})
+
+	return results
+}

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -1,0 +1,13 @@
+import { apiV1Fetch } from './client';
+import type { GetConfigResponse, PatchConfigRequest, PatchConfigResponse } from '@/types/config';
+
+export async function getConfig(): Promise<GetConfigResponse> {
+	return apiV1Fetch<GetConfigResponse>('/config/');
+}
+
+export async function patchConfig(patch: PatchConfigRequest): Promise<PatchConfigResponse> {
+	return apiV1Fetch<PatchConfigResponse>('/config/', {
+		method: 'PATCH',
+		body: JSON.stringify(patch),
+	});
+}

--- a/frontend/src/pages/Settings/Settings.module.scss
+++ b/frontend/src/pages/Settings/Settings.module.scss
@@ -84,6 +84,11 @@
 	font-size: 0.875rem;
 	color: var(--text-primary);
 
+	&[data-partial] {
+		background: color-mix(in oklab, var(--accent-warn) 10%, transparent);
+		border-color: color-mix(in oklab, var(--accent-warn) 30%, transparent);
+	}
+
 	> :first-child {
 		display: flex;
 		align-items: center;

--- a/frontend/src/pages/Settings/Settings.module.scss
+++ b/frontend/src/pages/Settings/Settings.module.scss
@@ -3,3 +3,510 @@
 .settingsPage {
 	max-width: 64rem;
 }
+
+// ---- Tab bar ----
+
+.tabBar {
+	display: flex;
+	gap: 0.25rem;
+	border-bottom: 2px solid var(--border-card);
+	margin-bottom: 1.5rem;
+}
+
+.tabBtn {
+	padding: 0.5rem 1.1rem;
+	font-size: 0.9rem;
+	font-weight: 500;
+	background: none;
+	border: none;
+	border-bottom: 2px solid transparent;
+	margin-bottom: -2px;
+	color: var(--text-secondary);
+	cursor: pointer;
+	transition: color var(--transition-fast), border-color var(--transition-fast);
+
+	&:hover {
+		color: var(--text-primary);
+	}
+
+	&[data-active] {
+		color: var(--accent-primary);
+		border-bottom-color: var(--accent-primary);
+	}
+}
+
+// ---- Config tab wrapper ----
+
+.configTab {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+// ---- Drift banner ----
+
+.driftBanner {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.6rem 1rem;
+	background: color-mix(in oklab, var(--accent-warn) 10%, transparent);
+	border: 1px solid color-mix(in oklab, var(--accent-warn) 30%, transparent);
+	border-radius: var(--input-radius);
+	color: var(--accent-warn);
+	font-size: 0.875rem;
+}
+
+.driftBadge {
+	display: inline-block;
+	margin-left: 0.4rem;
+	padding: 0.1rem 0.35rem;
+	font-size: 0.68rem;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	border-radius: 3px;
+	background: color-mix(in oklab, var(--accent-warn) 15%, transparent);
+	color: var(--accent-warn);
+	vertical-align: middle;
+}
+
+// ---- Save result banner ----
+
+.saveResultBanner {
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+	padding: 0.75rem 1rem;
+	background: color-mix(in oklab, var(--accent-success) 8%, transparent);
+	border: 1px solid color-mix(in oklab, var(--accent-success) 25%, transparent);
+	border-radius: var(--input-radius);
+	font-size: 0.875rem;
+	color: var(--text-primary);
+
+	> :first-child {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-weight: 500;
+	}
+}
+
+.saveResultRow {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.83rem;
+	padding-left: 0.25rem;
+}
+
+.saveResultError {
+	color: var(--accent-danger);
+	font-size: 0.8rem;
+	font-family: monospace;
+}
+
+.iconOk {
+	color: var(--accent-success);
+	flex-shrink: 0;
+}
+
+.iconFail {
+	color: var(--accent-danger);
+	flex-shrink: 0;
+}
+
+// ---- Config form ----
+
+.configForm {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	background: var(--bg-card);
+	border: 1px solid var(--border-card);
+	border-radius: var(--card-radius);
+	overflow: hidden;
+}
+
+.sectionHeader {
+	margin: 0;
+	padding: 0.55rem 1rem;
+	font-size: 0.75rem;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	color: var(--text-secondary);
+	background: var(--bg-header);
+	border-top: 1px solid var(--border-card);
+
+	&:first-child {
+		border-top: none;
+	}
+}
+
+.fieldRow {
+	display: grid;
+	grid-template-columns: 14rem 1fr;
+	align-items: start;
+	gap: 0.75rem 1rem;
+	padding: 0.65rem 1rem;
+	border-top: 1px solid var(--border-card);
+
+	@media (max-width: 48em) {
+		grid-template-columns: 1fr;
+	}
+}
+
+.fieldLabel {
+	padding-top: 0.35rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	color: var(--text-primary);
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 0.25rem;
+}
+
+.fieldControl {
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+}
+
+.fieldHint {
+	font-size: 0.78rem;
+	color: var(--text-secondary);
+}
+
+// ---- Form controls ----
+
+.input,
+.inputShort,
+.textarea,
+.select {
+	padding: 0.4rem 0.6rem;
+	font-size: 0.875rem;
+	font-family: inherit;
+	border: 1px solid var(--border-card);
+	border-radius: var(--input-radius);
+	background: var(--bg-page);
+	color: var(--text-primary);
+	transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+
+	&:focus {
+		outline: none;
+		border-color: var(--accent-primary);
+		box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+	}
+
+	&:disabled {
+		opacity: 0.6;
+	}
+}
+
+.input {
+	width: 100%;
+	max-width: 22rem;
+}
+
+.inputShort {
+	width: 7rem;
+}
+
+.textarea {
+	width: 100%;
+	max-width: 28rem;
+	resize: vertical;
+	min-height: 4.5rem;
+	font-family: monospace;
+	font-size: 0.83rem;
+}
+
+.select {
+	max-width: 22rem;
+	appearance: none;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%236a6a6a' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+	background-repeat: no-repeat;
+	background-position: right 0.5rem center;
+	padding-right: 2rem;
+}
+
+.toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	cursor: pointer;
+	font-size: 0.875rem;
+
+	input[type='checkbox'] {
+		width: 1rem;
+		height: 1rem;
+		cursor: pointer;
+		accent-color: var(--accent-primary);
+	}
+}
+
+.inlineRow {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}
+
+.inlineSep {
+	font-size: 0.875rem;
+	color: var(--text-secondary);
+}
+
+// ---- Config actions ----
+
+.configActions {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	justify-content: flex-end;
+	padding-top: 0.25rem;
+}
+
+.reloadBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.45rem 0.9rem;
+	font-size: 0.875rem;
+	background: var(--btn-surface-bg);
+	color: var(--btn-surface-text);
+	border: 1px solid var(--border-card);
+	border-radius: var(--input-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: var(--btn-surface-bg-hover);
+	}
+
+	&:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+}
+
+.saveBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.45rem 1rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	background: var(--btn-primary-bg);
+	color: var(--btn-primary-text);
+	border: none;
+	border-radius: var(--input-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast), opacity var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: var(--btn-primary-bg-hover);
+	}
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+}
+
+// ---- Diff / confirm modal ----
+
+.modalOverlay {
+	position: fixed;
+	inset: 0;
+	background: var(--bg-overlay);
+	z-index: 40;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 1rem;
+}
+
+.modal {
+	position: relative;
+	z-index: 50;
+	background: var(--bg-card);
+	border: 1px solid var(--border-card);
+	border-radius: var(--card-radius);
+	box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.25);
+	padding: 1.75rem;
+	width: min(52rem, calc(100vw - 2rem));
+	max-height: calc(100vh - 4rem);
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.modalTitle {
+	font-size: 1.1rem;
+	font-weight: 600;
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.modalSubtitle {
+	font-size: 0.875rem;
+	color: var(--text-secondary);
+	margin: 0;
+}
+
+.modalEmpty {
+	font-size: 0.875rem;
+	color: var(--text-secondary);
+	margin: 0;
+	font-style: italic;
+}
+
+.diffTable {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.875rem;
+
+	thead tr {
+		background: var(--bg-header);
+	}
+
+	th {
+		padding: 0.5rem 0.75rem;
+		text-align: left;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-secondary);
+		border-bottom: 1px solid var(--border-card);
+		white-space: nowrap;
+	}
+
+	tbody tr {
+		border-bottom: 1px solid var(--border-card);
+
+		&:last-child {
+			border-bottom: none;
+		}
+
+		&:nth-child(even) {
+			background: var(--bg-table-stripe);
+		}
+	}
+
+	td {
+		padding: 0.5rem 0.75rem;
+		vertical-align: top;
+		color: var(--text-primary);
+	}
+}
+
+.diffLabel {
+	font-weight: 500;
+	white-space: nowrap;
+}
+
+.diffCurrent {
+	font-family: monospace;
+	font-size: 0.82rem;
+	color: var(--text-secondary);
+	word-break: break-all;
+}
+
+.diffProposed {
+	font-family: monospace;
+	font-size: 0.82rem;
+	color: var(--accent-primary);
+	word-break: break-all;
+}
+
+.modalError {
+	color: var(--accent-danger);
+	font-size: 0.875rem;
+	margin: 0;
+}
+
+.modalActions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.5rem;
+}
+
+.cancelBtn {
+	padding: 0.45rem 1rem;
+	font-size: 0.875rem;
+	background: var(--btn-cancel-bg);
+	color: var(--btn-cancel-text);
+	border: 1px solid var(--btn-cancel-border);
+	border-radius: var(--input-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: var(--btn-cancel-bg-hover);
+	}
+
+	&:disabled {
+		opacity: 0.7;
+		cursor: not-allowed;
+	}
+}
+
+.confirmBtn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.45rem 1rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	background: var(--btn-primary-bg);
+	color: var(--btn-primary-text);
+	border: none;
+	border-radius: var(--input-radius);
+	cursor: pointer;
+	transition: background var(--transition-fast), opacity var(--transition-fast);
+
+	&:hover:not(:disabled) {
+		background: var(--btn-primary-bg-hover);
+	}
+
+	&:disabled {
+		opacity: 0.7;
+		cursor: not-allowed;
+	}
+}
+
+// ---- Loading / error states ----
+
+.configLoading {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 3rem 1rem;
+	justify-content: center;
+	color: var(--text-secondary);
+	font-size: 0.9rem;
+}
+
+.configError {
+	padding: 0.75rem 1rem;
+	background: color-mix(in oklab, var(--accent-danger) 10%, transparent);
+	color: var(--accent-danger);
+	border-radius: var(--input-radius);
+	font-size: 0.9rem;
+}
+
+// ---- Spin animation ----
+
+.spin {
+	animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+	from { transform: rotate(0deg); }
+	to { transform: rotate(360deg); }
+}

--- a/frontend/src/pages/Settings/Settings.module.scss
+++ b/frontend/src/pages/Settings/Settings.module.scss
@@ -71,6 +71,24 @@
 	vertical-align: middle;
 }
 
+// ---- Reload error banner ----
+
+.reloadErrorBanner {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.6rem 1rem;
+	background: color-mix(in oklab, var(--accent-danger) 10%, transparent);
+	border: 1px solid color-mix(in oklab, var(--accent-danger) 30%, transparent);
+	border-radius: var(--input-radius);
+	color: var(--accent-danger);
+	font-size: 0.875rem;
+
+	> button {
+		margin-left: auto;
+	}
+}
+
 // ---- Save result banner ----
 
 .saveResultBanner {

--- a/frontend/src/pages/Settings/Settings.tsx
+++ b/frontend/src/pages/Settings/Settings.tsx
@@ -1,10 +1,632 @@
+import { useState, useEffect, useCallback } from 'react';
+import { RefreshCw, AlertTriangle, CheckCircle, XCircle } from 'lucide-react';
 import { PiholeManagementList } from '@/components/PiholeManagementList';
+import { getConfig, patchConfig } from '@/lib/api/config';
+import { usePiholes } from '@/providers/PiholeProvider';
+import type { PiholeConfig, PatchConfigRequest, PatchConfigResponse } from '@/types/config';
 import styles from './Settings.module.scss';
 
+type Tab = 'nodes' | 'pihole-config';
+
+// ---------- helpers ----------
+
+function isDrifted(perNode: Record<string, PiholeConfig>, key: (c: PiholeConfig) => unknown): boolean {
+	const vals = Object.values(perNode).map(key);
+	if (vals.length < 2) return false;
+	const first = JSON.stringify(vals[0]);
+	return vals.some((v) => JSON.stringify(v) !== first);
+}
+
+// ---------- Config form state ----------
+
+type ConfigFormState = {
+	// DNS
+	upstreams: string; // newline-separated
+	interface: string;
+	port: string;
+	dnssec: boolean;
+	domainNeeded: boolean;
+	expandHosts: boolean;
+	localTTL: string;
+	blockingmode: string;
+	blockingipv4: string;
+	blockingipv6: string;
+	rateLimitCount: string;
+	rateLimitInterval: string;
+	revServerActive: boolean;
+	revServerCIDR: string;
+	revServerTarget: string;
+	revServerDomain: string;
+	piholePTR: string;
+	querylogEnabled: boolean;
+	// Misc
+	privacylevel: string;
+	// FTL
+	queryDisplay: string;
+	maxDBdays: string;
+	DBinterval: string;
+	// Webserver
+	excludeClients: string; // newline-separated
+	excludeDomains: string;
+	maxHistory: string;
+	// Resolver
+	resolveIPv4: boolean;
+	resolveIPv6: boolean;
+	networkNames: boolean;
+};
+
+function configToForm(cfg: PiholeConfig): ConfigFormState {
+	return {
+		upstreams: cfg.dns.upstreams.join('\n'),
+		interface: cfg.dns.interface,
+		port: String(cfg.dns.port),
+		dnssec: cfg.dns.dnssec,
+		domainNeeded: cfg.dns.domainNeeded,
+		expandHosts: cfg.dns.expandHosts,
+		localTTL: String(cfg.dns.localTTL),
+		blockingmode: cfg.dns.blockingmode,
+		blockingipv4: cfg.dns.blockingipv4,
+		blockingipv6: cfg.dns.blockingipv6,
+		rateLimitCount: String(cfg.dns.ratelimit.count),
+		rateLimitInterval: String(cfg.dns.ratelimit.interval),
+		revServerActive: cfg.dns.revServer.active,
+		revServerCIDR: cfg.dns.revServer.cidr,
+		revServerTarget: cfg.dns.revServer.target,
+		revServerDomain: cfg.dns.revServer.domain,
+		piholePTR: cfg.dns.piholePTR,
+		querylogEnabled: cfg.dns.querylog.enabled,
+		privacylevel: String(cfg.misc.privacylevel),
+		queryDisplay: cfg.ftl.query_display,
+		maxDBdays: String(cfg.ftl.database.maxDBdays),
+		DBinterval: String(cfg.ftl.database.DBinterval),
+		excludeClients: cfg.webserver.api.excludeClients.join('\n'),
+		excludeDomains: cfg.webserver.api.excludeDomains.join('\n'),
+		maxHistory: String(cfg.webserver.api.maxHistory),
+		resolveIPv4: cfg.resolver.resolveIPv4,
+		resolveIPv6: cfg.resolver.resolveIPv6,
+		networkNames: cfg.resolver.networkNames,
+	};
+}
+
+function formToPatch(form: ConfigFormState, original: PiholeConfig): PatchConfigRequest {
+	const patch: PatchConfigRequest = {};
+	const dns: PatchConfigRequest['dns'] = {};
+	const misc: PatchConfigRequest['misc'] = {};
+	const ftl: PatchConfigRequest['ftl'] = {};
+	const webserver: PatchConfigRequest['webserver'] = { api: {} };
+	const resolver: PatchConfigRequest['resolver'] = {};
+
+	const newUpstreams = form.upstreams.split('\n').map((s) => s.trim()).filter(Boolean);
+	if (JSON.stringify(newUpstreams) !== JSON.stringify(original.dns.upstreams)) dns.upstreams = newUpstreams;
+	if (form.interface !== original.dns.interface) dns.interface = form.interface;
+	const port = parseInt(form.port, 10);
+	if (!isNaN(port) && port !== original.dns.port) dns.port = port;
+	if (form.dnssec !== original.dns.dnssec) dns.dnssec = form.dnssec;
+	if (form.domainNeeded !== original.dns.domainNeeded) dns.domainNeeded = form.domainNeeded;
+	if (form.expandHosts !== original.dns.expandHosts) dns.expandHosts = form.expandHosts;
+	const localTTL = parseInt(form.localTTL, 10);
+	if (!isNaN(localTTL) && localTTL !== original.dns.localTTL) dns.localTTL = localTTL;
+	if (form.blockingmode !== original.dns.blockingmode) dns.blockingmode = form.blockingmode;
+	if (form.blockingipv4 !== original.dns.blockingipv4) dns.blockingipv4 = form.blockingipv4;
+	if (form.blockingipv6 !== original.dns.blockingipv6) dns.blockingipv6 = form.blockingipv6;
+
+	const rlCount = parseInt(form.rateLimitCount, 10);
+	const rlInterval = parseInt(form.rateLimitInterval, 10);
+	if (!isNaN(rlCount) && !isNaN(rlInterval) &&
+		(rlCount !== original.dns.ratelimit.count || rlInterval !== original.dns.ratelimit.interval)) {
+		dns.ratelimit = { count: rlCount, interval: rlInterval };
+	}
+
+	if (form.revServerActive !== original.dns.revServer.active ||
+		form.revServerCIDR !== original.dns.revServer.cidr ||
+		form.revServerTarget !== original.dns.revServer.target ||
+		form.revServerDomain !== original.dns.revServer.domain) {
+		dns.revServer = {
+			active: form.revServerActive,
+			cidr: form.revServerCIDR,
+			target: form.revServerTarget,
+			domain: form.revServerDomain,
+		};
+	}
+	if (form.piholePTR !== original.dns.piholePTR) dns.piholePTR = form.piholePTR;
+	if (form.querylogEnabled !== original.dns.querylog.enabled) dns.querylog = { enabled: form.querylogEnabled };
+
+	if (Object.keys(dns).length > 0) patch.dns = dns;
+
+	const pl = parseInt(form.privacylevel, 10);
+	if (!isNaN(pl) && pl !== original.misc.privacylevel) misc.privacylevel = pl;
+	if (Object.keys(misc).length > 0) patch.misc = misc;
+
+	if (form.queryDisplay !== original.ftl.query_display) ftl.query_display = form.queryDisplay;
+	const maxDBdays = parseInt(form.maxDBdays, 10);
+	const dbInterval = parseFloat(form.DBinterval);
+	if ((!isNaN(maxDBdays) && maxDBdays !== original.ftl.database.maxDBdays) ||
+		(!isNaN(dbInterval) && dbInterval !== original.ftl.database.DBinterval)) {
+		ftl.database = {};
+		if (!isNaN(maxDBdays)) ftl.database.maxDBdays = maxDBdays;
+		if (!isNaN(dbInterval)) ftl.database.DBinterval = dbInterval;
+	}
+	if (Object.keys(ftl).length > 0) patch.ftl = ftl;
+
+	const newExcClients = form.excludeClients.split('\n').map((s) => s.trim()).filter(Boolean);
+	const newExcDomains = form.excludeDomains.split('\n').map((s) => s.trim()).filter(Boolean);
+	const maxHist = parseInt(form.maxHistory, 10);
+	if (JSON.stringify(newExcClients) !== JSON.stringify(original.webserver.api.excludeClients))
+		webserver.api!.excludeClients = newExcClients;
+	if (JSON.stringify(newExcDomains) !== JSON.stringify(original.webserver.api.excludeDomains))
+		webserver.api!.excludeDomains = newExcDomains;
+	if (!isNaN(maxHist) && maxHist !== original.webserver.api.maxHistory)
+		webserver.api!.maxHistory = maxHist;
+	if (Object.keys(webserver.api!).length > 0) patch.webserver = webserver;
+
+	if (form.resolveIPv4 !== original.resolver.resolveIPv4) resolver.resolveIPv4 = form.resolveIPv4;
+	if (form.resolveIPv6 !== original.resolver.resolveIPv6) resolver.resolveIPv6 = form.resolveIPv6;
+	if (form.networkNames !== original.resolver.networkNames) resolver.networkNames = form.networkNames;
+	if (Object.keys(resolver).length > 0) patch.resolver = resolver;
+
+	return patch;
+}
+
+// ---------- Sub-components ----------
+
+function DriftBadge() {
+	return <span className={styles.driftBadge} title='Value differs across nodes'>drift</span>;
+}
+
+function FieldRow({ label, drifted, children }: { label: string; drifted?: boolean; children: React.ReactNode }) {
+	return (
+		<div className={styles.fieldRow}>
+			<label className={styles.fieldLabel}>
+				{label}
+				{drifted && <DriftBadge />}
+			</label>
+			<div className={styles.fieldControl}>{children}</div>
+		</div>
+	);
+}
+
+function SectionHeader({ title }: { title: string }) {
+	return <h3 className={styles.sectionHeader}>{title}</h3>;
+}
+
+// ---------- Diff modal ----------
+
+type DiffEntry = { label: string; current: string; proposed: string };
+
+function buildDiff(patch: PatchConfigRequest, original: PiholeConfig): DiffEntry[] {
+	const entries: DiffEntry[] = [];
+	const fmt = (v: unknown) => (v === undefined || v === null) ? '—' : JSON.stringify(v);
+	const add = (label: string, cur: unknown, next: unknown) => {
+		if (JSON.stringify(cur) !== JSON.stringify(next)) entries.push({ label, current: fmt(cur), proposed: fmt(next) });
+	};
+
+	if (patch.dns) {
+		const d = patch.dns;
+		if (d.upstreams !== undefined) add('DNS Upstreams', original.dns.upstreams, d.upstreams);
+		if (d.interface !== undefined) add('DNS Interface', original.dns.interface, d.interface);
+		if (d.port !== undefined) add('DNS Port', original.dns.port, d.port);
+		if (d.dnssec !== undefined) add('DNSSEC', original.dns.dnssec, d.dnssec);
+		if (d.domainNeeded !== undefined) add('Domain Needed', original.dns.domainNeeded, d.domainNeeded);
+		if (d.expandHosts !== undefined) add('Expand Hosts', original.dns.expandHosts, d.expandHosts);
+		if (d.localTTL !== undefined) add('Local TTL', original.dns.localTTL, d.localTTL);
+		if (d.blockingmode !== undefined) add('Blocking Mode', original.dns.blockingmode, d.blockingmode);
+		if (d.blockingipv4 !== undefined) add('Blocking IPv4', original.dns.blockingipv4, d.blockingipv4);
+		if (d.blockingipv6 !== undefined) add('Blocking IPv6', original.dns.blockingipv6, d.blockingipv6);
+		if (d.ratelimit !== undefined) add('Rate Limit', original.dns.ratelimit, d.ratelimit);
+		if (d.revServer !== undefined) add('Reverse Server', original.dns.revServer, d.revServer);
+		if (d.piholePTR !== undefined) add('Pi-hole PTR', original.dns.piholePTR, d.piholePTR);
+		if (d.querylog !== undefined) add('Query Log', original.dns.querylog, d.querylog);
+	}
+	if (patch.misc) {
+		if (patch.misc.privacylevel !== undefined) add('Privacy Level', original.misc.privacylevel, patch.misc.privacylevel);
+	}
+	if (patch.ftl) {
+		if (patch.ftl.query_display !== undefined) add('Query Display', original.ftl.query_display, patch.ftl.query_display);
+		if (patch.ftl.database !== undefined) add('FTL Database', original.ftl.database, patch.ftl.database);
+	}
+	if (patch.webserver?.api) {
+		const api = patch.webserver.api;
+		if (api.excludeClients !== undefined) add('Exclude Clients', original.webserver.api.excludeClients, api.excludeClients);
+		if (api.excludeDomains !== undefined) add('Exclude Domains', original.webserver.api.excludeDomains, api.excludeDomains);
+		if (api.maxHistory !== undefined) add('Max History', original.webserver.api.maxHistory, api.maxHistory);
+	}
+	if (patch.resolver) {
+		if (patch.resolver.resolveIPv4 !== undefined) add('Resolve IPv4', original.resolver.resolveIPv4, patch.resolver.resolveIPv4);
+		if (patch.resolver.resolveIPv6 !== undefined) add('Resolve IPv6', original.resolver.resolveIPv6, patch.resolver.resolveIPv6);
+		if (patch.resolver.networkNames !== undefined) add('Network Names', original.resolver.networkNames, patch.resolver.networkNames);
+	}
+	return entries;
+}
+
+// ---------- Config tab ----------
+
+function PiholeConfigTab() {
+	const { piholeNodes } = usePiholes();
+	const [loading, setLoading] = useState(false);
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [original, setOriginal] = useState<PiholeConfig | null>(null);
+	const [perNode, setPerNode] = useState<Record<string, PiholeConfig>>({});
+	const [globalDrift, setGlobalDrift] = useState(false);
+	const [form, setForm] = useState<ConfigFormState | null>(null);
+
+	const [diffOpen, setDiffOpen] = useState(false);
+	const [pendingPatch, setPendingPatch] = useState<PatchConfigRequest | null>(null);
+	const [saving, setSaving] = useState(false);
+	const [saveResult, setSaveResult] = useState<PatchConfigResponse | null>(null);
+	const [saveError, setSaveError] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		setLoading(true);
+		setLoadError(null);
+		try {
+			const resp = await getConfig();
+			setGlobalDrift(resp.drifted);
+			setPerNode(resp.perNode ?? {});
+			if (resp.consensus) {
+				setOriginal(resp.consensus);
+				setForm(configToForm(resp.consensus));
+			}
+		} catch (err) {
+			setLoadError(err instanceof Error ? err.message : 'Failed to load config');
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => { load(); }, [load]);
+
+	function handleSave() {
+		if (!form || !original) return;
+		const patch = formToPatch(form, original);
+		if (Object.keys(patch).length === 0) return;
+		setPendingPatch(patch);
+		setSaveResult(null);
+		setSaveError(null);
+		setDiffOpen(true);
+	}
+
+	async function handleConfirm() {
+		if (!pendingPatch) return;
+		setSaving(true);
+		try {
+			const result = await patchConfig(pendingPatch);
+			setSaveResult(result);
+			setDiffOpen(false);
+			// Reload to reflect what Pi-hole actually stored
+			await load();
+		} catch (err) {
+			setSaveError(err instanceof Error ? err.message : 'Failed to save config');
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	const set = (key: keyof ConfigFormState, val: string | boolean) =>
+		setForm((f) => f ? { ...f, [key]: val } : f);
+
+	const drift = (key: (c: PiholeConfig) => unknown) => isDrifted(perNode, key);
+
+	if (loading && !form) {
+		return (
+			<div className={styles.configLoading}>
+				<RefreshCw size={20} className={styles.spin} />
+				Loading config…
+			</div>
+		);
+	}
+	if (loadError) {
+		return <div className={styles.configError}>{loadError}</div>;
+	}
+	if (!form || !original) return null;
+
+	const diffEntries = pendingPatch ? buildDiff(pendingPatch, original) : [];
+	const hasChanges = form ? Object.keys(formToPatch(form, original)).length > 0 : false;
+
+	return (
+		<div className={styles.configTab}>
+			{globalDrift && (
+				<div className={styles.driftBanner}>
+					<AlertTriangle size={15} />
+					Config values differ across nodes — drifted fields are highlighted below. Saving will overwrite all nodes.
+				</div>
+			)}
+
+			{saveResult && (
+				<div className={styles.saveResultBanner}>
+					{Object.values(saveResult.nodes).every((n) => n.success) ? (
+						<><CheckCircle size={14} /> Config saved to all nodes</>
+					) : (
+						<><AlertTriangle size={14} /> Partially saved — some nodes failed</>
+					)}
+					{Object.values(saveResult.nodes).map((n) => (
+						<div key={n.node.id} className={styles.saveResultRow}>
+							{n.success
+								? <CheckCircle size={12} className={styles.iconOk} />
+								: <XCircle size={12} className={styles.iconFail} />}
+							<span>{n.node.name}</span>
+							{n.error && <span className={styles.saveResultError}>{n.error}</span>}
+						</div>
+					))}
+				</div>
+			)}
+
+			<div className={styles.configForm}>
+				<SectionHeader title='DNS — Upstream servers' />
+				<FieldRow label='Upstream resolvers' drifted={drift((c) => c.dns.upstreams)}>
+					<textarea
+						className={styles.textarea}
+						rows={3}
+						value={form.upstreams}
+						onChange={(e) => set('upstreams', e.target.value)}
+						placeholder='127.0.0.1#5335'
+					/>
+					<span className={styles.fieldHint}>One per line, e.g. 127.0.0.1#5335 or 8.8.8.8</span>
+				</FieldRow>
+
+				<SectionHeader title='DNS — Interface & port' />
+				<FieldRow label='Interface' drifted={drift((c) => c.dns.interface)}>
+					<input className={styles.input} value={form.interface} onChange={(e) => set('interface', e.target.value)} />
+				</FieldRow>
+				<FieldRow label='Port' drifted={drift((c) => c.dns.port)}>
+					<input className={styles.inputShort} type='number' min={1} max={65535} value={form.port}
+						onChange={(e) => set('port', e.target.value)} />
+				</FieldRow>
+
+				<SectionHeader title='DNS — Options' />
+				<FieldRow label='DNSSEC' drifted={drift((c) => c.dns.dnssec)}>
+					<label className={styles.toggle}>
+						<input type='checkbox' checked={form.dnssec} onChange={(e) => set('dnssec', e.target.checked)} />
+						<span>{form.dnssec ? 'Enabled' : 'Disabled'}</span>
+					</label>
+				</FieldRow>
+				<FieldRow label='Domain needed' drifted={drift((c) => c.dns.domainNeeded)}>
+					<label className={styles.toggle}>
+						<input type='checkbox' checked={form.domainNeeded} onChange={(e) => set('domainNeeded', e.target.checked)} />
+						<span>{form.domainNeeded ? 'Enabled' : 'Disabled'}</span>
+					</label>
+				</FieldRow>
+				<FieldRow label='Expand hosts' drifted={drift((c) => c.dns.expandHosts)}>
+					<label className={styles.toggle}>
+						<input type='checkbox' checked={form.expandHosts} onChange={(e) => set('expandHosts', e.target.checked)} />
+						<span>{form.expandHosts ? 'Enabled' : 'Disabled'}</span>
+					</label>
+				</FieldRow>
+				<FieldRow label='Local TTL (s)' drifted={drift((c) => c.dns.localTTL)}>
+					<input className={styles.inputShort} type='number' min={0} value={form.localTTL}
+						onChange={(e) => set('localTTL', e.target.value)} />
+				</FieldRow>
+
+				<SectionHeader title='DNS — Blocking' />
+				<FieldRow label='Blocking mode' drifted={drift((c) => c.dns.blockingmode)}>
+					<select className={styles.select} value={form.blockingmode} onChange={(e) => set('blockingmode', e.target.value)}>
+						<option value='NULL'>NULL (recommended)</option>
+						<option value='IP'>IP</option>
+						<option value='IP-NODATA-AAAA'>IP-NODATA-AAAA</option>
+						<option value='NXDOMAIN'>NXDOMAIN</option>
+					</select>
+				</FieldRow>
+				{(form.blockingmode === 'IP' || form.blockingmode === 'IP-NODATA-AAAA') && (
+					<>
+						<FieldRow label='Blocking IPv4' drifted={drift((c) => c.dns.blockingipv4)}>
+							<input className={styles.input} value={form.blockingipv4} onChange={(e) => set('blockingipv4', e.target.value)} />
+						</FieldRow>
+						<FieldRow label='Blocking IPv6' drifted={drift((c) => c.dns.blockingipv6)}>
+							<input className={styles.input} value={form.blockingipv6} onChange={(e) => set('blockingipv6', e.target.value)} />
+						</FieldRow>
+					</>
+				)}
+
+				<SectionHeader title='DNS — Rate limiting' />
+				<FieldRow label='Queries / interval' drifted={drift((c) => c.dns.ratelimit)}>
+					<div className={styles.inlineRow}>
+						<input className={styles.inputShort} type='number' min={0} value={form.rateLimitCount}
+							onChange={(e) => set('rateLimitCount', e.target.value)} />
+						<span className={styles.inlineSep}>queries per</span>
+						<input className={styles.inputShort} type='number' min={1} value={form.rateLimitInterval}
+							onChange={(e) => set('rateLimitInterval', e.target.value)} />
+						<span className={styles.inlineSep}>seconds</span>
+					</div>
+				</FieldRow>
+
+				<SectionHeader title='DNS — Reverse server' />
+				<FieldRow label='Active' drifted={drift((c) => c.dns.revServer.active)}>
+					<label className={styles.toggle}>
+						<input type='checkbox' checked={form.revServerActive} onChange={(e) => set('revServerActive', e.target.checked)} />
+						<span>{form.revServerActive ? 'Enabled' : 'Disabled'}</span>
+					</label>
+				</FieldRow>
+				{form.revServerActive && (
+					<>
+						<FieldRow label='CIDR' drifted={drift((c) => c.dns.revServer.cidr)}>
+							<input className={styles.input} value={form.revServerCIDR} onChange={(e) => set('revServerCIDR', e.target.value)} placeholder='192.168.0.0/24' />
+						</FieldRow>
+						<FieldRow label='Target' drifted={drift((c) => c.dns.revServer.target)}>
+							<input className={styles.input} value={form.revServerTarget} onChange={(e) => set('revServerTarget', e.target.value)} placeholder='192.168.0.1' />
+						</FieldRow>
+						<FieldRow label='Domain' drifted={drift((c) => c.dns.revServer.domain)}>
+							<input className={styles.input} value={form.revServerDomain} onChange={(e) => set('revServerDomain', e.target.value)} placeholder='local' />
+						</FieldRow>
+					</>
+				)}
+
+				<SectionHeader title='DNS — Pi-hole PTR' />
+				<FieldRow label='Pi-hole PTR' drifted={drift((c) => c.dns.piholePTR)}>
+					<select className={styles.select} value={form.piholePTR} onChange={(e) => set('piholePTR', e.target.value)}>
+						<option value='PI.HOLE'>PI.HOLE — return "pi.hole"</option>
+						<option value='HOSTNAME'>HOSTNAME — return machine hostname</option>
+						<option value='HOSTNAMEFQDN'>HOSTNAMEFQDN — return FQDN</option>
+						<option value='NONE'>NONE — disabled</option>
+					</select>
+				</FieldRow>
+
+				<SectionHeader title='Query logging' />
+				<FieldRow label='Query log' drifted={drift((c) => c.dns.querylog.enabled)}>
+					<label className={styles.toggle}>
+						<input type='checkbox' checked={form.querylogEnabled} onChange={(e) => set('querylogEnabled', e.target.checked)} />
+						<span>{form.querylogEnabled ? 'Enabled' : 'Disabled'}</span>
+					</label>
+				</FieldRow>
+				<FieldRow label='Max DB retention (days)' drifted={drift((c) => c.ftl.database.maxDBdays)}>
+					<input className={styles.inputShort} type='number' min={0} value={form.maxDBdays}
+						onChange={(e) => set('maxDBdays', e.target.value)} />
+				</FieldRow>
+				<FieldRow label='DB write interval (min)' drifted={drift((c) => c.ftl.database.DBinterval)}>
+					<input className={styles.inputShort} type='number' min={0} step='0.1' value={form.DBinterval}
+						onChange={(e) => set('DBinterval', e.target.value)} />
+				</FieldRow>
+
+				<SectionHeader title='Privacy' />
+				<FieldRow label='Privacy level' drifted={drift((c) => c.misc.privacylevel)}>
+					<select className={styles.select} value={form.privacylevel}
+						onChange={(e) => set('privacylevel', e.target.value)}>
+						<option value='0'>0 — Show everything</option>
+						<option value='1'>1 — Hide domains</option>
+						<option value='2'>2 — Hide domains & clients</option>
+						<option value='3'>3 — Anonymous mode</option>
+					</select>
+				</FieldRow>
+
+				<SectionHeader title='API' />
+				<FieldRow label='Exclude clients' drifted={drift((c) => c.webserver.api.excludeClients)}>
+					<textarea className={styles.textarea} rows={3} value={form.excludeClients}
+						onChange={(e) => set('excludeClients', e.target.value)}
+						placeholder='One IP per line' />
+				</FieldRow>
+				<FieldRow label='Exclude domains' drifted={drift((c) => c.webserver.api.excludeDomains)}>
+					<textarea className={styles.textarea} rows={3} value={form.excludeDomains}
+						onChange={(e) => set('excludeDomains', e.target.value)}
+						placeholder='One domain per line' />
+				</FieldRow>
+				<FieldRow label='Max history (h)' drifted={drift((c) => c.webserver.api.maxHistory)}>
+					<input className={styles.inputShort} type='number' min={1} value={form.maxHistory}
+						onChange={(e) => set('maxHistory', e.target.value)} />
+				</FieldRow>
+
+				<SectionHeader title='FTL' />
+				<FieldRow label='Query display' drifted={drift((c) => c.ftl.query_display)}>
+					<select className={styles.select} value={form.queryDisplay}
+						onChange={(e) => set('queryDisplay', e.target.value)}>
+						<option value='public'>public</option>
+						<option value='hidden'>hidden</option>
+						<option value='none'>none</option>
+					</select>
+				</FieldRow>
+
+				<SectionHeader title='Resolver' />
+				<FieldRow label='Resolve IPv4' drifted={drift((c) => c.resolver.resolveIPv4)}>
+					<label className={styles.toggle}>
+						<input type='checkbox' checked={form.resolveIPv4} onChange={(e) => set('resolveIPv4', e.target.checked)} />
+						<span>{form.resolveIPv4 ? 'Enabled' : 'Disabled'}</span>
+					</label>
+				</FieldRow>
+				<FieldRow label='Resolve IPv6' drifted={drift((c) => c.resolver.resolveIPv6)}>
+					<label className={styles.toggle}>
+						<input type='checkbox' checked={form.resolveIPv6} onChange={(e) => set('resolveIPv6', e.target.checked)} />
+						<span>{form.resolveIPv6 ? 'Enabled' : 'Disabled'}</span>
+					</label>
+				</FieldRow>
+				<FieldRow label='Network names' drifted={drift((c) => c.resolver.networkNames)}>
+					<label className={styles.toggle}>
+						<input type='checkbox' checked={form.networkNames} onChange={(e) => set('networkNames', e.target.checked)} />
+						<span>{form.networkNames ? 'Enabled' : 'Disabled'}</span>
+					</label>
+				</FieldRow>
+			</div>
+
+			<div className={styles.configActions}>
+				<button type='button' className={styles.reloadBtn} onClick={load} disabled={loading}>
+					<RefreshCw size={14} className={loading ? styles.spin : undefined} />
+					Reload
+				</button>
+				<button type='button' className={styles.saveBtn} onClick={handleSave} disabled={!hasChanges || loading}>
+					Save changes…
+				</button>
+			</div>
+
+			{/* Diff / confirm modal */}
+			{diffOpen && pendingPatch && (
+				<div className={styles.modalOverlay}>
+					<div className={styles.modal}>
+						<h2 className={styles.modalTitle}>Review changes</h2>
+						<p className={styles.modalSubtitle}>
+							These changes will be applied to all {piholeNodes.length} node{piholeNodes.length !== 1 ? 's' : ''}.
+						</p>
+						{diffEntries.length === 0 ? (
+							<p className={styles.modalEmpty}>No changes detected.</p>
+						) : (
+							<table className={styles.diffTable}>
+								<thead>
+									<tr>
+										<th>Setting</th>
+										<th>Current</th>
+										<th>Proposed</th>
+									</tr>
+								</thead>
+								<tbody>
+									{diffEntries.map((e) => (
+										<tr key={e.label}>
+											<td className={styles.diffLabel}>{e.label}</td>
+											<td className={styles.diffCurrent}>{e.current}</td>
+											<td className={styles.diffProposed}>{e.proposed}</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						)}
+						{saveError && <p className={styles.modalError}>{saveError}</p>}
+						<div className={styles.modalActions}>
+							<button type='button' className={styles.cancelBtn}
+								onClick={() => { setDiffOpen(false); setPendingPatch(null); }}
+								disabled={saving}>
+								Cancel
+							</button>
+							<button type='button' className={styles.confirmBtn}
+								onClick={handleConfirm}
+								disabled={saving || diffEntries.length === 0}
+								aria-busy={saving}>
+								{saving ? <RefreshCw size={14} className={styles.spin} /> : null}
+								{saving ? 'Applying…' : 'Apply to all nodes'}
+							</button>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ---------- Main Settings ----------
+
 export function Settings() {
+	const [tab, setTab] = useState<Tab>('nodes');
+
 	return (
 		<div className={styles.settingsPage}>
-			<PiholeManagementList title='Pi-hole Nodes' />
+			<div className={styles.tabBar} role='tablist'>
+				<button
+					role='tab'
+					type='button'
+					className={styles.tabBtn}
+					data-active={tab === 'nodes' || undefined}
+					onClick={() => setTab('nodes')}
+					aria-selected={tab === 'nodes'}
+				>
+					Nodes
+				</button>
+				<button
+					role='tab'
+					type='button'
+					className={styles.tabBtn}
+					data-active={tab === 'pihole-config' || undefined}
+					onClick={() => setTab('pihole-config')}
+					aria-selected={tab === 'pihole-config'}
+				>
+					Pi-hole Config
+				</button>
+			</div>
+
+			{tab === 'nodes' && <PiholeManagementList title='Pi-hole Nodes' />}
+			{tab === 'pihole-config' && <PiholeConfigTab />}
 		</div>
 	);
 }

--- a/frontend/src/pages/Settings/Settings.tsx
+++ b/frontend/src/pages/Settings/Settings.tsx
@@ -346,7 +346,7 @@ function PiholeConfigTab() {
 				<div className={styles.reloadErrorBanner}>
 					<AlertTriangle size={14} />
 					<span>Failed to reload: {loadError}</span>
-					<button type='button' className={styles.reloadBtn} onClick={() => load(true)}>Retry</button>
+					<button type='button' className={styles.reloadBtn} onClick={() => load(true)} disabled={loading}>Retry</button>
 				</div>
 			)}
 			{globalDrift && (

--- a/frontend/src/pages/Settings/Settings.tsx
+++ b/frontend/src/pages/Settings/Settings.tsx
@@ -176,10 +176,10 @@ function DriftBadge() {
 function FieldRow({ label, drifted, children }: { label: string; drifted?: boolean; children: React.ReactNode }) {
 	return (
 		<div className={styles.fieldRow}>
-			<label className={styles.fieldLabel}>
+			<div className={styles.fieldLabel}>
 				{label}
 				{drifted && <DriftBadge />}
-			</label>
+			</div>
 			<div className={styles.fieldControl}>{children}</div>
 		</div>
 	);
@@ -335,14 +335,20 @@ function PiholeConfigTab() {
 			</div>
 		);
 	}
-	if (loadError) {
+	if (loadError && !form) {
 		return <div className={styles.configError}>{loadError}</div>;
 	}
 	if (!form || !original) return null;
 
-
 	return (
 		<div className={styles.configTab}>
+			{loadError && (
+				<div className={styles.reloadErrorBanner}>
+					<AlertTriangle size={14} />
+					<span>Failed to reload: {loadError}</span>
+					<button type='button' className={styles.reloadBtn} onClick={() => load(true)}>Retry</button>
+				</div>
+			)}
 			{globalDrift && (
 				<div className={styles.driftBanner}>
 					<AlertTriangle size={15} />

--- a/frontend/src/pages/Settings/Settings.tsx
+++ b/frontend/src/pages/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useId } from 'react';
+import { useState, useEffect, useCallback, useMemo, useId, useRef } from 'react';
 import { RefreshCw, AlertTriangle, CheckCircle, XCircle } from 'lucide-react';
 import { PiholeManagementList } from '@/components/PiholeManagementList';
 import { getConfig, patchConfig } from '@/lib/api/config';
@@ -255,13 +255,19 @@ function PiholeConfigTab() {
 	const [saveResult, setSaveResult] = useState<PatchConfigResponse | null>(null);
 	const [saveError, setSaveError] = useState<string | null>(null);
 
+	// Refs give the load callback stable access to current form/original without
+	// recreating it on every keystroke (avoids useCallback deps churn).
+	const formRef = useRef(form);
+	const originalRef = useRef(original);
+	useEffect(() => { formRef.current = form; originalRef.current = original; });
+
 	const load = useCallback(async (force = false) => {
-		if (!force && form && Object.keys(formToPatch(form, original!)).length > 0) {
+		if (!force && formRef.current && originalRef.current &&
+			Object.keys(formToPatch(formRef.current, originalRef.current)).length > 0) {
 			if (!window.confirm('You have unsaved changes. Reload and discard them?')) return;
 		}
 		setLoading(true);
 		setLoadError(null);
-		setSaveResult(null);
 		try {
 			const resp = await getConfig();
 			setGlobalDrift(resp.drifted);
@@ -276,9 +282,9 @@ function PiholeConfigTab() {
 		} finally {
 			setLoading(false);
 		}
-	}, [form, original]);
+	}, []);
 
-	useEffect(() => { load(true); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+	useEffect(() => { load(true); }, [load]);
 
 	function handleSave() {
 		if (!form || !original) return;

--- a/frontend/src/pages/Settings/Settings.tsx
+++ b/frontend/src/pages/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo, useId } from 'react';
 import { RefreshCw, AlertTriangle, CheckCircle, XCircle } from 'lucide-react';
 import { PiholeManagementList } from '@/components/PiholeManagementList';
 import { getConfig, patchConfig } from '@/lib/api/config';
@@ -255,9 +255,13 @@ function PiholeConfigTab() {
 	const [saveResult, setSaveResult] = useState<PatchConfigResponse | null>(null);
 	const [saveError, setSaveError] = useState<string | null>(null);
 
-	const load = useCallback(async () => {
+	const load = useCallback(async (force = false) => {
+		if (!force && form && Object.keys(formToPatch(form, original!)).length > 0) {
+			if (!window.confirm('You have unsaved changes. Reload and discard them?')) return;
+		}
 		setLoading(true);
 		setLoadError(null);
+		setSaveResult(null);
 		try {
 			const resp = await getConfig();
 			setGlobalDrift(resp.drifted);
@@ -268,12 +272,13 @@ function PiholeConfigTab() {
 			}
 		} catch (err) {
 			setLoadError(err instanceof Error ? err.message : 'Failed to load config');
+			setSaveResult(null);
 		} finally {
 			setLoading(false);
 		}
-	}, []);
+	}, [form, original]);
 
-	useEffect(() => { load(); }, [load]);
+	useEffect(() => { load(true); }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 	function handleSave() {
 		if (!form || !original) return;
@@ -293,7 +298,7 @@ function PiholeConfigTab() {
 			setSaveResult(result);
 			setDiffOpen(false);
 			// Reload to reflect what Pi-hole actually stored
-			await load();
+			await load(true);
 		} catch (err) {
 			setSaveError(err instanceof Error ? err.message : 'Failed to save config');
 		} finally {
@@ -305,6 +310,16 @@ function PiholeConfigTab() {
 		setForm((f) => f ? { ...f, [key]: val } : f);
 
 	const drift = (key: (c: PiholeConfig) => unknown) => isDrifted(perNode, key);
+
+	const hasChanges = useMemo(
+		() => !!(form && original && Object.keys(formToPatch(form, original)).length > 0),
+		[form, original],
+	);
+
+	const diffEntries = useMemo(
+		() => (pendingPatch && original ? buildDiff(pendingPatch, original) : []),
+		[pendingPatch, original],
+	);
 
 	if (loading && !form) {
 		return (
@@ -319,8 +334,6 @@ function PiholeConfigTab() {
 	}
 	if (!form || !original) return null;
 
-	const diffEntries = pendingPatch ? buildDiff(pendingPatch, original) : [];
-	const hasChanges = form ? Object.keys(formToPatch(form, original)).length > 0 : false;
 
 	return (
 		<div className={styles.configTab}>
@@ -332,7 +345,7 @@ function PiholeConfigTab() {
 			)}
 
 			{saveResult && (
-				<div className={styles.saveResultBanner}>
+				<div className={styles.saveResultBanner} data-partial={!Object.values(saveResult.nodes).every((n) => n.success) || undefined}>
 					{Object.values(saveResult.nodes).every((n) => n.success) ? (
 						<><CheckCircle size={14} /> Config saved to all nodes</>
 					) : (
@@ -534,7 +547,7 @@ function PiholeConfigTab() {
 			</div>
 
 			<div className={styles.configActions}>
-				<button type='button' className={styles.reloadBtn} onClick={load} disabled={loading}>
+				<button type='button' className={styles.reloadBtn} onClick={() => load(false)} disabled={loading}>
 					<RefreshCw size={14} className={loading ? styles.spin : undefined} />
 					Reload
 				</button>
@@ -599,34 +612,48 @@ function PiholeConfigTab() {
 
 export function Settings() {
 	const [tab, setTab] = useState<Tab>('nodes');
+	const nodesId = useId();
+	const configId = useId();
 
 	return (
 		<div className={styles.settingsPage}>
 			<div className={styles.tabBar} role='tablist'>
 				<button
+					id={`${nodesId}-tab`}
 					role='tab'
 					type='button'
 					className={styles.tabBtn}
 					data-active={tab === 'nodes' || undefined}
 					onClick={() => setTab('nodes')}
 					aria-selected={tab === 'nodes'}
+					aria-controls={`${nodesId}-panel`}
 				>
 					Nodes
 				</button>
 				<button
+					id={`${configId}-tab`}
 					role='tab'
 					type='button'
 					className={styles.tabBtn}
 					data-active={tab === 'pihole-config' || undefined}
 					onClick={() => setTab('pihole-config')}
 					aria-selected={tab === 'pihole-config'}
+					aria-controls={`${configId}-panel`}
 				>
 					Pi-hole Config
 				</button>
 			</div>
 
-			{tab === 'nodes' && <PiholeManagementList title='Pi-hole Nodes' />}
-			{tab === 'pihole-config' && <PiholeConfigTab />}
+			{tab === 'nodes' && (
+				<div id={`${nodesId}-panel`} role='tabpanel' aria-labelledby={`${nodesId}-tab`}>
+					<PiholeManagementList title='Pi-hole Nodes' />
+				</div>
+			)}
+			{tab === 'pihole-config' && (
+				<div id={`${configId}-panel`} role='tabpanel' aria-labelledby={`${configId}-tab`}>
+					<PiholeConfigTab />
+				</div>
+			)}
 		</div>
 	);
 }

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -1,0 +1,85 @@
+export type ConfigDNS = {
+	upstreams: string[];
+	interface: string;
+	port: number;
+	dnssec: boolean;
+	domainNeeded: boolean;
+	expandHosts: boolean;
+	localTTL: number;
+	blockingmode: string;
+	blockingipv4: string;
+	blockingipv6: string;
+	ratelimit: { count: number; interval: number };
+	revServer: { active: boolean; cidr: string; target: string; domain: string };
+	piholePTR: string;
+	querylog: { enabled: boolean };
+};
+
+export type ConfigMisc = {
+	privacylevel: number;
+	delay_startup: number;
+	nice: number;
+};
+
+export type ConfigFTL = {
+	query_display: string;
+	delay_startup: number;
+	database: { DBinterval: number; maxDBdays: number };
+};
+
+export type ConfigWebserver = {
+	api: { excludeClients: string[]; excludeDomains: string[]; maxHistory: number };
+};
+
+export type ConfigResolver = {
+	resolveIPv4: boolean;
+	resolveIPv6: boolean;
+	networkNames: boolean;
+};
+
+export type PiholeConfig = {
+	dns: ConfigDNS;
+	misc: ConfigMisc;
+	ftl: ConfigFTL;
+	webserver: ConfigWebserver;
+	resolver: ConfigResolver;
+};
+
+export type GetConfigResponse = {
+	consensus: PiholeConfig | null;
+	perNode: Record<string, PiholeConfig>;
+	drifted: boolean;
+};
+
+export type PatchConfigRequest = {
+	dns?: Partial<{
+		upstreams: string[];
+		interface: string;
+		port: number;
+		dnssec: boolean;
+		domainNeeded: boolean;
+		expandHosts: boolean;
+		localTTL: number;
+		blockingmode: string;
+		blockingipv4: string;
+		blockingipv6: string;
+		ratelimit: { count?: number; interval?: number };
+		revServer: { active?: boolean; cidr?: string; target?: string; domain?: string };
+		piholePTR: string;
+		querylog: { enabled?: boolean };
+	}>;
+	misc?: Partial<ConfigMisc>;
+	ftl?: Partial<{ query_display: string; delay_startup: number; database: Partial<{ DBinterval: number; maxDBdays: number }> }>;
+	webserver?: { api?: Partial<{ excludeClients: string[]; excludeDomains: string[]; maxHistory: number }> };
+	resolver?: Partial<ConfigResolver>;
+};
+
+export type PatchConfigNodeResult = {
+	node: { id: number; name: string; host: string };
+	success: boolean;
+	error?: string;
+};
+
+export type PatchConfigResponse = {
+	nodes: Record<string, PatchConfigNodeResult>;
+};

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -47,6 +47,7 @@ export type PiholeConfig = {
 
 export type GetConfigResponse = {
 	consensus: PiholeConfig | null;
+	// Keys are node IDs serialized as strings (Go encodes int64 map keys as JSON strings).
 	perNode: Record<string, PiholeConfig>;
 	drifted: boolean;
 };


### PR DESCRIPTION
## Summary

- Adds a tabbed Settings page (Nodes | Pi-hole Config) replacing the single-panel layout
- Full Pi-hole v6 config management: load cluster config, detect node drift, edit all config keys, preview diff before applying, fan-out PATCH to every node
- Per-field drift badges highlight fields that disagree across nodes; a global drift banner appears when any config diverges
- Minimal-patch logic — only changed fields are sent in the PATCH body

## Backend changes

- `domain/config.go` — `PiholeConfig`, `ClusterConfig`, `PiholeConfigPatch` domain types with pointer-based patch sub-types
- `pihole/client.go` — `GetConfig` (GET `/api/config`) and `PatchConfig` (PATCH `/api/config`) Pi-hole v6 API calls
- `pihole/cluster.go` — cluster fan-out for `GetConfig` and `PatchConfig` (5 s per-node timeout)
- `pihole/wire.go` — wire response/request types, `configFromWire` and `patchToWire` converters
- `service/configsvc` — `GetClusterConfig` (drift detection via `reflect.DeepEqual`), `PatchConfig` (fan-out + audit log)
- `api/v1` — `GET /config` and `PATCH /config` handlers with full DTO layer

## Frontend changes

- `types/config.ts` + `lib/api/config.ts` — typed API client for config endpoints
- `Settings.tsx` — completely rewritten with tab bar; `PiholeConfigTab` includes all config sections (DNS, blocking, rate limiting, reverse server, query log/FTL DB, privacy, API, resolver), per-field drift badges, save preview modal with diff table, per-node save result display
- `Settings.module.scss` — all CSS classes for the new UI (tabs, config form, drift indicators, diff table, modal)

## Test plan

- [ ] Open Settings → Pi-hole Config tab; verify config loads and form fields are populated
- [ ] With a 2-node cluster where configs differ, confirm global drift banner and per-field drift badges appear
- [ ] Edit a field (e.g. toggle DNSSEC), click "Save changes…", verify diff modal shows only the changed field
- [ ] Confirm → verify config applied to all nodes and save result banner shows per-node success/failure
- [ ] With a node offline, verify save result shows failure for that node and success for healthy nodes
- [ ] Reload button re-fetches config without full page refresh
- [ ] Nodes tab still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)